### PR TITLE
feat: catch errors in DO's fetch

### DIFF
--- a/.changeset/smooth-lemons-march.md
+++ b/.changeset/smooth-lemons-march.md
@@ -1,0 +1,8 @@
+---
+"partyserver": patch
+---
+
+feat: catch errors in DO's fetch
+
+Catch errors in a DO's fetch. Basic.
+We log the error stack right now which isn't a great thing, we'll revisit that later.


### PR DESCRIPTION
Catch errors in a DO's fetch. Basic.
We log the error stack right now which isn't a great thing, we'll revisit that later.