### PR TITLE
Emit next value in microtask queue

### DIFF
--- a/.changeset/quiet-yaks-yell.md
+++ b/.changeset/quiet-yaks-yell.md
@@ -1,0 +1,5 @@
+---
+"partytracks": patch
+---
+
+Emit useValueAsObservable next values in microtask

--- a/packages/partytracks/src/react/rxjsHooks.ts
+++ b/packages/partytracks/src/react/rxjsHooks.ts
@@ -60,7 +60,9 @@ export function useValueAsObservable<T>(value: T): Observable<T> {
   const previousValue = useRef<T>(undefined);
   if (previousValue.current !== value) {
     previousValue.current = value;
-    ref.current.next(value);
+    // since subscribers might call a setState, we don't want to
+    // do this in the render path.
+    queueMicrotask(() => ref.current.next(value));
   }
 
   useEffect(() => {


### PR DESCRIPTION
Since subscribers might call a React setState function, we don't want to emit the next value in the render path, so we'll queue it instead.