### PR TITLE
feat: Add header support to partywhen webhooks

### DIFF
--- a/packages/partywhen/README.md
+++ b/packages/partywhen/README.md
@@ -36,6 +36,7 @@ export default {
 
 A task has a few parts:
 
+- **id**: a unique identifier for the task
 - **description**: which is a string that you can use to identify the task
 - **payload**: which is a JSON object that is passed to the task
 - **type**: which is one of "delayed", "cron", or "scheduled"
@@ -54,6 +55,7 @@ Here are some examples:
 
   ```ts
   scheduler.scheduleTask({
+    id: "my-task",
     description: "my-task",
     type: "delayed",
     delayInSeconds: 60,
@@ -71,6 +73,7 @@ Here are some examples:
 
   ```ts
   scheduler.scheduleTask({
+    id: "my-task",
     description: "my-task",
     type: "cron",
     cron: "0 18 * * 5",
@@ -90,6 +93,7 @@ Here are some examples:
 
   ```ts
   scheduler.scheduleTask({
+    id: "my-task",
     description: "my-task",
     type: "scheduled",
     time: new Date("2024-01-01T12:00:00Z"),

--- a/packages/partywhen/src/index.ts
+++ b/packages/partywhen/src/index.ts
@@ -63,6 +63,7 @@ type Callback =
   | {
       type: "webhook";
       url: string;
+      headers?: Record<string, string>;
     }
   | {
       type: "durable-object";
@@ -359,6 +360,7 @@ export class Scheduler<Env> extends Server<Env> {
           method: "POST",
           body: JSON.stringify(task),
           headers: {
+            ...(task.callback.headers || {}),
             "Content-Type": "application/json"
           }
         });


### PR DESCRIPTION
This PR:

1. Fixes an issue with the readme docs not specifying an ID is required when creating a task
2. Adds support for passing headers to the webhook callback type, useful for when you need to pass things like signed JWTs so the webhook receiving the event can validate it's legit 