### PR TITLE
Stop transceiver of a closed track

### DIFF
--- a/packages/partytracks/src/client/PartyTracks.ts
+++ b/packages/partytracks/src/client/PartyTracks.ts
@@ -557,7 +557,7 @@ export class PartyTracks {
     ) {
       return;
     }
-
+    transceiver.stop()
     this.closeTrackDispatcher.doBulkRequest({ mid }, (mids) =>
       this.taskScheduler.schedule(async () => {
         // create an offer


### PR DESCRIPTION
This makes possible to reuse an inactive transceiver later and reduce the size of a WebRTC SDP after removing and adding tracks several times