### PR TITLE
Stop transceiver right before renegotiating

### DIFF
--- a/.changeset/sharp-impalas-switch.md
+++ b/.changeset/sharp-impalas-switch.md
@@ -1,0 +1,7 @@
+---
+"partytracks": patch
+---
+
+Bug fix: Stop transceiver right before renegotiating. This avoids a potential undesirable outcome where
+a transceiver could be released and _potentially_ re-used in a subsequent negotiation before the track
+is actually closed.

--- a/packages/partytracks/src/client/PartyTracks.ts
+++ b/packages/partytracks/src/client/PartyTracks.ts
@@ -607,9 +607,9 @@ export class PartyTracks {
     ) {
       return;
     }
-    transceiver.stop();
     this.closeTrackDispatcher.doBulkRequest({ mid }, (mids) =>
       this.taskScheduler.schedule(async () => {
+        transceiver.stop();
         // create an offer
         const offer = await peerConnection.createOffer();
         // And set the offer as the local description


### PR DESCRIPTION
This avoids a potential undesirable outcome wherea transceiver could be released and *potentially* re-used in a subsequent negotiation before the trackis actually closed.