### PR TITLE
await the call that sets a party's name inside getServerByName

### DIFF
--- a/.changeset/silver-aliens-teach.md
+++ b/.changeset/silver-aliens-teach.md
@@ -1,0 +1,5 @@
+---
+"partyserver": patch
+---
+
+await the call that sets a party's name inside getServerByName

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -56,8 +56,8 @@ export async function getServerByName<Env, T extends Server<Env>>(
 
   req.headers.set("x-partykit-room", name);
 
-  // Note the lack of await
-  stub.fetch(req).catch((e) => {
+  // unfortunately we have to await this
+  await stub.fetch(req).catch((e) => {
     console.error("Could not set server name:", e);
   });
 


### PR DESCRIPTION
sigh, too buggy to not await it 