### PR TITLE
fix(y-partyserver): make onMessage overridable via super

### DIFF
--- a/packages/y-partyserver/src/server/index.ts
+++ b/packages/y-partyserver/src/server/index.ts
@@ -335,9 +335,13 @@ export class YServer<Env = unknown> extends Server<Env> {
     }
   }
 
-  onMessage = handleChunked((conn, message) =>
+  private handleChunkedMessage = handleChunked((conn, message) =>
     this.handleMessage(conn, message)
   );
+
+  onMessage(conn: Connection, message: WSMessage): void {
+    this.handleChunkedMessage(conn, message);
+  }
 
   onClose(
     connection: Connection<unknown>,


### PR DESCRIPTION
## Problem

When extending `YServer` to handle custom string messages alongside Yjs binary messages, developers couldn't override `onMessage` and call `super.onMessage()` because it was defined as a class field rather than a method.

```typescript
// This didn't work ❌
class MyYServer extends YServer {
  onMessage(conn, message) {
    if (typeof message === "string") {
      // handle custom JSON
      return;
    }
    super.onMessage(conn, message); // undefined - class fields aren't on prototype
  }
}
```

## Solution

Refactored `onMessage` from a class field to a proper method, moving the chunking handler to a private `handleChunkedMessage` field.

```typescript
// Now works ✓
class MyYServer extends YServer {
  onMessage(conn, message) {
    if (typeof message === "string") {
      const data = JSON.parse(message);
      // handle custom messages
      return;
    }
    super.onMessage(conn, message); // properly delegates to parent
  }
}
```

This enables mixed message handling (custom JSON + Yjs protocol) without modifying the library internals.