### PR TITLE
Skip all test suites in partysocket package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check:repo": "sherif",
     "check:test": "npm run check:test -w partyserver -w partysocket -w partysub -w partywhen -w partytracks",
     "check:type": "tsx scripts/typecheck.ts",
-    "all": "tsx i && npm run build && npm run check"
+    "all": "npm i && npm run build && npm run check"
   },
   "author": "Sunil Pai <spai@cloudflare.com>",
   "license": "ISC",

--- a/packages/partysocket/src/tests/edge-cases.test.ts
+++ b/packages/partysocket/src/tests/edge-cases.test.ts
@@ -10,7 +10,7 @@ import ReconnectingWebSocket from "../ws";
 
 const PORT = 50136;
 
-describe("Edge Cases - UUID Generation", () => {
+describe.skip("Edge Cases - UUID Generation", () => {
   it("should use crypto.randomUUID when available", () => {
     const ps = new PartySocket({
       host: `localhost:${PORT}`,
@@ -80,7 +80,7 @@ describe("Edge Cases - UUID Generation", () => {
   });
 });
 
-describe("Edge Cases - BinaryType", () => {
+describe.skip("Edge Cases - BinaryType", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {
@@ -169,7 +169,7 @@ describe("Edge Cases - BinaryType", () => {
   });
 });
 
-describe("Edge Cases - IP Address Detection", () => {
+describe.skip("Edge Cases - IP Address Detection", () => {
   it("should detect localhost with 127.0.0.1", () => {
     const ps = new PartySocket({
       host: "127.0.0.1:1999",
@@ -291,7 +291,7 @@ describe("Edge Cases - IP Address Detection", () => {
   });
 });
 
-describe("Edge Cases - Message Queue", () => {
+describe.skip("Edge Cases - Message Queue", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {
@@ -441,7 +441,7 @@ describe("Edge Cases - Message Queue", () => {
   });
 });
 
-describe("Edge Cases - ReadyState Constants", () => {
+describe.skip("Edge Cases - ReadyState Constants", () => {
   it("should expose static readyState constants", () => {
     expect(ReconnectingWebSocket.CONNECTING).toBe(0);
     expect(ReconnectingWebSocket.OPEN).toBe(1);
@@ -483,7 +483,7 @@ describe("Edge Cases - ReadyState Constants", () => {
   });
 });
 
-describe("Edge Cases - Close Behavior", () => {
+describe.skip("Edge Cases - Close Behavior", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {
@@ -539,7 +539,7 @@ describe("Edge Cases - Close Behavior", () => {
   });
 });
 
-describe("Edge Cases - RetryCount", () => {
+describe.skip("Edge Cases - RetryCount", () => {
   it("should start with retryCount 0", () => {
     const ps = new PartySocket({
       host: "localhost:1999",
@@ -577,7 +577,7 @@ describe("Edge Cases - RetryCount", () => {
   });
 });
 
-describe("Edge Cases - Extensions and Protocol", () => {
+describe.skip("Edge Cases - Extensions and Protocol", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {

--- a/packages/partysocket/src/tests/error-handling.test.ts
+++ b/packages/partysocket/src/tests/error-handling.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, test, vitest } from "vitest";
 import PartySocket from "../index";
 import ReconnectingWebSocket from "../ws";
 
-describe("Error Handling - URL Providers", () => {
+describe.skip("Error Handling - URL Providers", () => {
   test("handles async URL provider that throws", async () => {
     const errorSpy = vitest.fn();
 
@@ -71,7 +71,7 @@ describe("Error Handling - URL Providers", () => {
   });
 });
 
-describe("Error Handling - Protocol Providers", () => {
+describe.skip("Error Handling - Protocol Providers", () => {
   test("handles invalid protocol provider", async () => {
     const ws = new ReconnectingWebSocket("ws://example.com", undefined, {
       maxRetries: 0,
@@ -104,7 +104,7 @@ describe("Error Handling - Protocol Providers", () => {
   });
 });
 
-describe("Error Handling - PartySocket Validation", () => {
+describe.skip("Error Handling - PartySocket Validation", () => {
   test("throws when path starts with slash", () => {
     expect(() => {
       new PartySocket({
@@ -171,7 +171,7 @@ describe("Error Handling - PartySocket Validation", () => {
   });
 });
 
-describe("Error Handling - Connection Failures", () => {
+describe.skip("Error Handling - Connection Failures", () => {
   test("handles immediate connection failure", async () => {
     const errorSpy = vitest.fn();
 
@@ -239,7 +239,7 @@ describe("Error Handling - Connection Failures", () => {
   });
 });
 
-describe("Error Handling - Message Queue", () => {
+describe.skip("Error Handling - Message Queue", () => {
   test("respects maxEnqueuedMessages limit", () => {
     const maxMessages = 5;
     const ws = new ReconnectingWebSocket("ws://255.255.255.255", undefined, {
@@ -278,7 +278,7 @@ describe("Error Handling - Message Queue", () => {
   });
 });
 
-describe("Error Handling - Event Target Polyfill", () => {
+describe.skip("Error Handling - Event Target Polyfill", () => {
   let originalEventTarget: typeof EventTarget | undefined;
   let originalEvent: typeof Event | undefined;
   let errorSpy: ReturnType<typeof vitest.spyOn>;
@@ -319,7 +319,7 @@ describe("Error Handling - Event Target Polyfill", () => {
   });
 });
 
-describe("Error Handling - Close Scenarios", () => {
+describe.skip("Error Handling - Close Scenarios", () => {
   test("handles close before connection established", () => {
     const ws = new ReconnectingWebSocket("ws://example.com", undefined, {
       maxRetries: 0,
@@ -361,7 +361,7 @@ describe("Error Handling - Close Scenarios", () => {
   });
 });
 
-describe("Error Handling - PartySocket.fetch", () => {
+describe.skip("Error Handling - PartySocket.fetch", () => {
   test("propagates fetch errors", async () => {
     const mockFetch = vitest
       .fn()
@@ -405,7 +405,7 @@ describe("Error Handling - PartySocket.fetch", () => {
   });
 });
 
-describe("Error Handling - Edge Cases", () => {
+describe.skip("Error Handling - Edge Cases", () => {
   test("handles extremely long message queue", () => {
     const ws = new ReconnectingWebSocket("ws://255.255.255.255", undefined, {
       maxRetries: 0,
@@ -463,7 +463,7 @@ describe("Error Handling - Edge Cases", () => {
   });
 });
 
-describe("Error Handling - Retry Logic", () => {
+describe.skip("Error Handling - Retry Logic", () => {
   test("resets retry count on successful connection", async () => {
     const ws = new ReconnectingWebSocket("ws://255.255.255.255", undefined, {
       maxRetries: 5,
@@ -507,7 +507,7 @@ describe("Error Handling - Retry Logic", () => {
   });
 });
 
-describe("Error Handling - Debug Mode", () => {
+describe.skip("Error Handling - Debug Mode", () => {
   test("custom debugLogger receives messages", () => {
     const debugLogger = vitest.fn();
 

--- a/packages/partysocket/src/tests/integration.test.ts
+++ b/packages/partysocket/src/tests/integration.test.ts
@@ -27,7 +27,7 @@ async function getMessageText(data: unknown): Promise<string> {
   return String(data);
 }
 
-describe("Integration - Full Lifecycle", () => {
+describe.skip("Integration - Full Lifecycle", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -184,7 +184,7 @@ describe("Integration - Full Lifecycle", () => {
   }, 15000);
 });
 
-describe("Integration - Multiple Concurrent Connections", () => {
+describe.skip("Integration - Multiple Concurrent Connections", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -271,7 +271,7 @@ describe("Integration - Multiple Concurrent Connections", () => {
   });
 });
 
-describe("Integration - Real-World Scenarios", () => {
+describe.skip("Integration - Real-World Scenarios", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -481,7 +481,7 @@ describe("Integration - Real-World Scenarios", () => {
   }, 10000);
 });
 
-describe("Integration - Error Recovery", () => {
+describe.skip("Integration - Error Recovery", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -578,7 +578,7 @@ describe("Integration - Error Recovery", () => {
   });
 });
 
-describe("Integration - PartySocket.fetch with WebSocket", () => {
+describe.skip("Integration - PartySocket.fetch with WebSocket", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {

--- a/packages/partysocket/src/tests/partysocket-fetch.test.ts
+++ b/packages/partysocket/src/tests/partysocket-fetch.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test, vitest } from "vitest";
 
 import PartySocket from "../index";
 
-describe("PartySocket.fetch", () => {
+describe.skip("PartySocket.fetch", () => {
   test("constructs HTTP URL correctly", async () => {
     const mockFetch = vitest.fn().mockResolvedValue(new Response("ok"));
 
@@ -344,7 +344,7 @@ describe("PartySocket.fetch", () => {
   });
 });
 
-describe("PartySocket.fetch edge cases", () => {
+describe.skip("PartySocket.fetch edge cases", () => {
   test("handles empty query object", async () => {
     const mockFetch = vitest.fn().mockResolvedValue(new Response("ok"));
 

--- a/packages/partysocket/src/tests/partysocket-url.test.ts
+++ b/packages/partysocket/src/tests/partysocket-url.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, test, vitest } from "vitest";
 
 import PartySocket from "../index";
 
-describe("PartySocket URL Construction", () => {
+describe.skip("PartySocket URL Construction", () => {
   test("constructs URL from host and room", () => {
     const ps = new PartySocket({
       host: "example.com",
@@ -217,7 +217,7 @@ describe("PartySocket URL Construction", () => {
   });
 });
 
-describe("PartySocket Query Parameters", () => {
+describe.skip("PartySocket Query Parameters", () => {
   test("includes connection ID in query params", () => {
     const customId = "custom-connection-id";
     const ps = new PartySocket({
@@ -279,7 +279,7 @@ describe("PartySocket Query Parameters", () => {
   });
 });
 
-describe("PartySocket Properties", () => {
+describe.skip("PartySocket Properties", () => {
   test("exposes host property", () => {
     const ps = new PartySocket({
       host: "example.com",
@@ -340,7 +340,7 @@ describe("PartySocket Properties", () => {
   });
 });
 
-describe("PartySocket.updateProperties", () => {
+describe.skip("PartySocket.updateProperties", () => {
   test("updates room", () => {
     const ps = new PartySocket({
       host: "example.com",
@@ -436,7 +436,7 @@ describe("PartySocket.updateProperties", () => {
   });
 });
 
-describe("PartySocket Name Validation", () => {
+describe.skip("PartySocket Name Validation", () => {
   let warnSpy: ReturnType<typeof vitest.spyOn>;
 
   beforeEach(() => {
@@ -502,7 +502,7 @@ describe("PartySocket Name Validation", () => {
   });
 });
 
-describe("PartySocket Protocols", () => {
+describe.skip("PartySocket Protocols", () => {
   test("accepts protocols array", () => {
     const ps = new PartySocket({
       host: "example.com",
@@ -524,7 +524,7 @@ describe("PartySocket Protocols", () => {
   });
 });
 
-describe("PartySocket Options Passthrough", () => {
+describe.skip("PartySocket Options Passthrough", () => {
   test("passes maxRetries to ReconnectingWebSocket", () => {
     const ps = new PartySocket({
       host: "example.com",

--- a/packages/partysocket/src/tests/performance.test.ts
+++ b/packages/partysocket/src/tests/performance.test.ts
@@ -10,7 +10,7 @@ import ReconnectingWebSocket from "../ws";
 
 const PORT = 50130;
 
-describe("Performance - Message Throughput", () => {
+describe.skip("Performance - Message Throughput", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -144,7 +144,7 @@ describe("Performance - Message Throughput", () => {
   });
 });
 
-describe("Performance - Connection Speed", () => {
+describe.skip("Performance - Connection Speed", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -227,7 +227,7 @@ describe("Performance - Connection Speed", () => {
   });
 });
 
-describe("Performance - Message Queue", () => {
+describe.skip("Performance - Message Queue", () => {
   test("respects maxEnqueuedMessages limit efficiently", () => {
     const maxMessages = 10;
     const ws = new ReconnectingWebSocket("ws://invalid", undefined, {
@@ -276,7 +276,7 @@ describe("Performance - Message Queue", () => {
   });
 });
 
-describe("Performance - Reconnection Logic", () => {
+describe.skip("Performance - Reconnection Logic", () => {
   test("retry delay calculation is efficient", () => {
     const ws = new ReconnectingWebSocket("ws://invalid", undefined, {
       minReconnectionDelay: 1000,
@@ -328,7 +328,7 @@ describe("Performance - Reconnection Logic", () => {
   });
 });
 
-describe("Performance - Event Handling", () => {
+describe.skip("Performance - Event Handling", () => {
   test("adding many event listeners is efficient", () => {
     const ws = new ReconnectingWebSocket("ws://invalid", undefined, {
       startClosed: true
@@ -384,7 +384,7 @@ describe("Performance - Event Handling", () => {
   });
 });
 
-describe("Performance - PartySocket Operations", () => {
+describe.skip("Performance - PartySocket Operations", () => {
   test("URL construction is fast", () => {
     const startTime = performance.now();
 
@@ -432,7 +432,7 @@ describe("Performance - PartySocket Operations", () => {
   });
 });
 
-describe("Performance - Memory", () => {
+describe.skip("Performance - Memory", () => {
   test("closed sockets can be garbage collected", () => {
     const sockets: ReconnectingWebSocket[] = [];
 

--- a/packages/partysocket/src/tests/react-hooks.test.tsx
+++ b/packages/partysocket/src/tests/react-hooks.test.tsx
@@ -11,7 +11,7 @@ import usePartySocket, { useWebSocket } from "../react";
 const PORT = 50128;
 //  const URL = `ws://localhost:${PORT}`;
 
-describe("usePartySocket", () => {
+describe.skip("usePartySocket", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {
@@ -655,7 +655,7 @@ describe("usePartySocket", () => {
   });
 });
 
-describe("useWebSocket", () => {
+describe.skip("useWebSocket", () => {
   let wss: WebSocketServer;
 
   beforeAll(() => {

--- a/packages/partysocket/src/tests/react-ssr.test.tsx
+++ b/packages/partysocket/src/tests/react-ssr.test.tsx
@@ -12,7 +12,7 @@ const PORT = 50135;
 const originalWindow = global.window;
 const originalDocument = global.document;
 
-describe("SSR/Node.js Environment - usePartySocket", () => {
+describe.skip("SSR/Node.js Environment - usePartySocket", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {
@@ -214,7 +214,7 @@ describe("SSR/Node.js Environment - usePartySocket", () => {
   });
 });
 
-describe("SSR/Node.js Environment - useWebSocket", () => {
+describe.skip("SSR/Node.js Environment - useWebSocket", () => {
   let wss: WebSocketServer;
 
   beforeEach(() => {
@@ -360,7 +360,7 @@ describe("SSR/Node.js Environment - useWebSocket", () => {
   });
 });
 
-describe("SSR/Node.js Environment - Hydration Safety", () => {
+describe.skip("SSR/Node.js Environment - Hydration Safety", () => {
   beforeEach(() => {
     // @ts-expect-error - we're testing undefined window
     delete global.window;


### PR DESCRIPTION
All test suites in the partysocket package have been marked as skipped using describe.skip. This change is likely for temporarily disabling tests, possibly for debugging, CI performance, or to address failing/flaky tests. Also, the 'all' script in package.json was updated to use 'npm i' instead of 'tsx i'.