### PR TITLE
Add `enabled` prop to usePartySocket and useWebSocket hooks

### DIFF
--- a/.changeset/bright-sockets-flow.md
+++ b/.changeset/bright-sockets-flow.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Add `enabled` prop to `usePartySocket` and `useWebSocket` hooks for conditional connection control

--- a/packages/partysocket/src/react.ts
+++ b/packages/partysocket/src/react.ts
@@ -7,9 +7,11 @@ import {
 
 import type { PartySocketOptions } from "./index";
 import type { EventHandlerOptions } from "./use-handlers";
+import type { SocketOptions } from "./use-socket";
 
 type UsePartySocketOptions = Omit<PartySocketOptions, "host"> &
-  EventHandlerOptions & {
+  EventHandlerOptions &
+  Pick<SocketOptions, "enabled"> & {
     host?: string | undefined;
   };
 

--- a/packages/partysocket/src/use-ws.ts
+++ b/packages/partysocket/src/use-ws.ts
@@ -6,9 +6,10 @@ import {
 import WebSocket from "./ws";
 
 import type { EventHandlerOptions } from "./use-handlers";
-import type { Options, ProtocolsProvider, UrlProvider } from "./ws";
+import type { SocketOptions } from "./use-socket";
+import type { ProtocolsProvider, UrlProvider } from "./ws";
 
-type UseWebSocketOptions = Options & EventHandlerOptions;
+type UseWebSocketOptions = SocketOptions & EventHandlerOptions;
 
 // A React hook that wraps PartySocket
 export default function useWebSocket(


### PR DESCRIPTION
Introduces an `enabled` option to both `usePartySocket` and `useWebSocket` hooks, allowing conditional control over socket connection state. Updates internal logic to handle connection, disconnection, and reconnection based on the `enabled` prop. Adds comprehensive tests to verify the new behavior.