### PR TITLE
Add CORS support to `routePartykitRequest`.

### DIFF
--- a/.changeset/cors-support.md
+++ b/.changeset/cors-support.md
@@ -1,0 +1,7 @@
+---
+"partyserver": patch
+---
+
+Add CORS support to `routePartykitRequest`.
+
+Pass `cors: true` for permissive defaults or `cors: { ...headers }` for custom CORS headers. Preflight (OPTIONS) requests are handled automatically for matched routes, and CORS headers are appended to all non-WebSocket responses — including responses returned by `onBeforeRequest`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12235,7 +12235,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "hono": "^4.11.1",
-        "partyserver": "^0.1.2"
+        "partyserver": "^0.1.3"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12260,7 +12260,7 @@
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.6",
-        "partysocket": "^1.1.11"
+        "partysocket": "^1.1.12"
       }
     },
     "packages/partyhard": {
@@ -12327,8 +12327,8 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.1.2",
-        "partysocket": "^1.1.11"
+        "partyserver": "^0.1.3",
+        "partysocket": "^1.1.12"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12345,7 +12345,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.1.2"
+        "partyserver": "^0.1.3"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12367,7 +12367,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.4.0",
-        "partyserver": "^0.1.2"
+        "partyserver": "^0.1.3"
       }
     },
     "packages/y-partyserver": {
@@ -12382,7 +12382,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "@types/lodash.debounce": "^4.0.9",
-        "partyserver": "^0.1.2",
+        "partyserver": "^0.1.3",
         "ws": "^8.18.3",
         "yjs": "^13.6.28"
       },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "hono": "^4.11.1",
-    "partyserver": "^0.1.2"
+    "partyserver": "^0.1.3"
   }
 }

--- a/packages/partyfn/package.json
+++ b/packages/partyfn/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "nanoid": "^5.1.6",
-    "partysocket": "^1.1.11"
+    "partysocket": "^1.1.12"
   },
   "scripts": {
     "build": "tsx scripts/build.ts"

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -34,6 +34,14 @@
       {
         "name": "StateRoundTrip",
         "class_name": "StateRoundTrip"
+      },
+      {
+        "name": "CorsServer",
+        "class_name": "CorsServer"
+      },
+      {
+        "name": "CustomCorsServer",
+        "class_name": "CustomCorsServer"
       }
     ]
   },
@@ -49,6 +57,10 @@
         "ConfigurableStateInMemory",
         "StateRoundTrip"
       ]
+    },
+    {
+      "tag": "v3",
+      "new_classes": ["CorsServer", "CustomCorsServer"]
     }
   ]
 }

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.1.2",
-    "partysocket": "^1.1.11"
+    "partyserver": "^0.1.3",
+    "partysocket": "^1.1.12"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.1.2"
+    "partyserver": "^0.1.3"
   }
 }

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.4.0",
-    "partyserver": "^0.1.2"
+    "partyserver": "^0.1.3"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "@types/lodash.debounce": "^4.0.9",
-    "partyserver": "^0.1.2",
+    "partyserver": "^0.1.3",
     "ws": "^8.18.3",
     "yjs": "^13.6.28"
   }


### PR DESCRIPTION
Pass `cors: true` for permissive defaults or `cors: { ...headers }` for custom CORS headers. Preflight (OPTIONS) requests are handled automatically for matched routes, and CORS headers are appended to all non-WebSocket responses — including responses returned by `onBeforeRequest`.