### PR TITLE
Fix: `reconnect()` not working after `maxRetries` exhausted

### DIFF
--- a/.changeset/fix-reconnect-after-max-retries.md
+++ b/.changeset/fix-reconnect-after-max-retries.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Fix `reconnect()` not working after `maxRetries` has been exhausted. The `_connectLock` was not released when the max retries early return was hit in `_connect()`, preventing any subsequent `reconnect()` call from initiating a new connection.

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -455,6 +455,7 @@ export default class ReconnectingWebSocket extends (EventTarget as TypedEventTar
 
     if (this._retryCount >= maxRetries) {
       this._debug("max retries reached", this._retryCount, ">=", maxRetries);
+      this._connectLock = false;
       return;
     }
 


### PR DESCRIPTION
### Summary

Fixes [cloudflare/partykit#252](https://github.com/cloudflare/partykit/issues/252) — calling `ws.reconnect()` after `maxRetries` has been exhausted now correctly resets and initiates a new connection.

### Problem

In `_connect()`, when `maxRetries` is reached, the method acquires `_connectLock = true` but returns early without releasing it. This leaves the lock permanently held, so any subsequent call to `reconnect()` (which resets `_retryCount` and calls `_connect()`) silently bails out at the lock check — making it impossible to manually reconnect after automatic retries are exhausted.

This is a common scenario when a user wants to force a reconnection on window focus after the tab has been inactive and retries have been spent.

### Fix

Release `_connectLock` before the early return in the `maxRetries` guard inside `_connect()`:

```diff
 if (this._retryCount >= maxRetries) {
   this._debug("max retries reached", this._retryCount, ">=", maxRetries);
+  this._connectLock = false;
   return;
 }
```
 
### Test plan
- Added a test that connects to an unreachable URL with maxRetries: 0, waits for retries to exhaust, then calls reconnect() with a valid URL and verifies the connection opens successfully.
- All existing 38 tests in reconnecting.test.ts continue to pass.
