### PR TITLE
Fix initialization race conditions and improve error resilience.

### DIFF
--- a/.changeset/fix-initialization-race-conditions.md
+++ b/.changeset/fix-initialization-race-conditions.md
@@ -1,0 +1,11 @@
+---
+"partyserver": patch
+---
+
+Fix initialization race conditions and improve error resilience.
+
+- `getServerByName` now propagates errors from the internal `set-name` request instead of silently swallowing them.
+- `onStart` failures no longer permanently brick the Durable Object. Errors are caught inside `blockConcurrencyWhile` (preserving the input gate) and the status is reset, allowing subsequent requests to retry initialization.
+- `fetch()` now retries initialization when a previous `onStart` attempt failed, instead of skipping it because the name was already set.
+- Errors in `fetch()` (including `onStart` failures and malformed props) are now caught and returned as proper 500 responses instead of crashing as unhandled exceptions.
+- WebSocket handlers (`webSocketMessage`, `webSocketClose`, `webSocketError`) are now wrapped in try/catch so that transient `onStart` failures don't kill the connection — the next message will retry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12235,7 +12235,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "hono": "^4.11.1",
-        "partyserver": "^0.1.3"
+        "partyserver": "^0.1.4"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12260,7 +12260,7 @@
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.6",
-        "partysocket": "^1.1.12"
+        "partysocket": "^1.1.13"
       }
     },
     "packages/partyhard": {
@@ -12327,8 +12327,8 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.1.3",
-        "partysocket": "^1.1.12"
+        "partyserver": "^0.1.4",
+        "partysocket": "^1.1.13"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12345,7 +12345,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.1.3"
+        "partyserver": "^0.1.4"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12367,7 +12367,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.4.0",
-        "partyserver": "^0.1.3"
+        "partyserver": "^0.1.4"
       }
     },
     "packages/y-partyserver": {
@@ -12382,7 +12382,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "@types/lodash.debounce": "^4.0.9",
-        "partyserver": "^0.1.3",
+        "partyserver": "^0.1.4",
         "ws": "^8.18.3",
         "yjs": "^13.6.28"
       },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "hono": "^4.11.1",
-    "partyserver": "^0.1.3"
+    "partyserver": "^0.1.4"
   }
 }

--- a/packages/partyfn/package.json
+++ b/packages/partyfn/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "nanoid": "^5.1.6",
-    "partysocket": "^1.1.12"
+    "partysocket": "^1.1.13"
   },
   "scripts": {
     "build": "tsx scripts/build.ts"

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -50,29 +50,34 @@
       {
         "name": "AlarmServer",
         "class_name": "AlarmServer"
+      },
+      {
+        "name": "FailingOnStartServer",
+        "class_name": "FailingOnStartServer"
+      },
+      {
+        "name": "HibernatingNameInMessage",
+        "class_name": "HibernatingNameInMessage"
       }
     ]
   },
   "migrations": [
     {
-      "tag": "v1", // Should be unique for each entry
-      "new_classes": ["Stateful", "OnStartServer", "Mixed"]
-    },
-    {
-      "tag": "v2",
+      "tag": "v1",
       "new_classes": [
+        "Stateful",
+        "OnStartServer",
+        "Mixed",
         "ConfigurableState",
         "ConfigurableStateInMemory",
-        "StateRoundTrip"
+        "StateRoundTrip",
+        "CorsServer",
+        "CustomCorsServer",
+        "HibernatingOnStartServer",
+        "AlarmServer",
+        "FailingOnStartServer",
+        "HibernatingNameInMessage"
       ]
-    },
-    {
-      "tag": "v3",
-      "new_classes": ["CorsServer", "CustomCorsServer"]
-    },
-    {
-      "tag": "v4",
-      "new_classes": ["HibernatingOnStartServer", "AlarmServer"]
     }
   ]
 }

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.1.3",
-    "partysocket": "^1.1.12"
+    "partyserver": "^0.1.4",
+    "partysocket": "^1.1.13"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.1.3"
+    "partyserver": "^0.1.4"
   }
 }

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.4.0",
-    "partyserver": "^0.1.3"
+    "partyserver": "^0.1.4"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "@types/lodash.debounce": "^4.0.9",
-    "partyserver": "^0.1.3",
+    "partyserver": "^0.1.4",
     "ws": "^8.18.3",
     "yjs": "^13.6.28"
   }


### PR DESCRIPTION
- `getServerByName` now propagates errors from the internal `set-name` request instead of silently swallowing them.
- `onStart` failures no longer permanently brick the Durable Object. Errors are caught inside `blockConcurrencyWhile` (preserving the input gate) and the status is reset, allowing subsequent requests to retry initialization.
- `fetch()` now retries initialization when a previous `onStart` attempt failed, instead of skipping it because the name was already set.
- Errors in `fetch()` (including `onStart` failures and malformed props) are now caught and returned as proper 500 responses instead of crashing as unhandled exceptions.
- WebSocket handlers (`webSocketMessage`, `webSocketClose`, `webSocketError`) are now wrapped in try/catch so that transient `onStart` failures don't kill the connection — the next message will retry.