### PR TITLE
Expose and validate connection.tags property

### DIFF
--- a/.changeset/connection-tags-property.md
+++ b/.changeset/connection-tags-property.md
@@ -1,0 +1,5 @@
+---
+"partyserver": minor
+---
+
+Add `connection.tags` property to read back tags assigned via `getConnectionTags()`. Works in both hibernating and in-memory modes. Tags are validated and always include the connection id as the first tag.

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -431,6 +431,7 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
         let connection: Connection = Object.assign(serverWebSocket, {
           id: connectionId,
           server: this.name,
+          tags: [] as string[],
           state: null as unknown as ConnectionState<unknown>,
           setState<T = unknown>(setState: T | ConnectionSetStateFn<T>) {
             let state: T;

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -58,6 +58,14 @@
       {
         "name": "HibernatingNameInMessage",
         "class_name": "HibernatingNameInMessage"
+      },
+      {
+        "name": "TagsServer",
+        "class_name": "TagsServer"
+      },
+      {
+        "name": "TagsServerInMemory",
+        "class_name": "TagsServerInMemory"
       }
     ]
   },
@@ -76,7 +84,9 @@
         "HibernatingOnStartServer",
         "AlarmServer",
         "FailingOnStartServer",
-        "HibernatingNameInMessage"
+        "HibernatingNameInMessage",
+        "TagsServer",
+        "TagsServerInMemory"
       ]
     }
   ]

--- a/packages/partyserver/src/types.ts
+++ b/packages/partyserver/src/types.ts
@@ -71,6 +71,12 @@ export type Connection<TState = unknown> = WebSocket & {
   deserializeAttachment<T = unknown>(): T | null;
 
   /**
+   * Tags assigned to this connection via {@link Server.getConnectionTags}.
+   * Always includes the connection id as the first tag.
+   */
+  tags: readonly string[];
+
+  /**
    * Server's name
    */
   server: string;


### PR DESCRIPTION
Fixes https://github.com/cloudflare/partykit/issues/254

Add a read-only connection.tags property and tag handling across the partyserver Durable Object. Introduces prepareTags() to dedupe and validate tags (always prepends the connection id, max 10 tags, non-empty strings, <=256 chars). Persist tags in the connection attachment for hibernating connections (default to [] for older attachments) and expose tags on in-memory connections via a property. Update createLazyConnection, connection attachment parsing, and both connection managers to use the helper. Includes type updates, new tests covering hibernating and in-memory tag behavior, and wrangler test config additions.