### PR TITLE
fix: recover Server.name from storage on alarm wake

### DIFF
--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -641,6 +641,8 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
     }
     this.#_name = name;
 
+    await this.ctx.storage.put("__partyserver_name", name);
+
     if (this.#status !== "started") {
       await this.#initialize();
     }
@@ -793,6 +795,12 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
   }
 
   async alarm(): Promise<void> {
+    if (!this.#_name) {
+      const stored = await this.ctx.storage.get<string>("__partyserver_name");
+      if (stored) {
+        this.#_name = stored;
+      }
+    }
     if (this.#status !== "started") {
       // This means the server "woke up" after hibernation
       // so we need to hydrate it again

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -66,6 +66,10 @@
       {
         "name": "TagsServerInMemory",
         "class_name": "TagsServerInMemory"
+      },
+      {
+        "name": "AlarmNameServer",
+        "class_name": "AlarmNameServer"
       }
     ]
   },
@@ -86,7 +90,8 @@
         "FailingOnStartServer",
         "HibernatingNameInMessage",
         "TagsServer",
-        "TagsServerInMemory"
+        "TagsServerInMemory",
+        "AlarmNameServer"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Persist `Server.name` to DO storage in `setName()`, recover it at the top of `alarm()` when `#_name` is unset
- Fixes crash when `this.name` is read inside `onAlarm()` or schedule callbacks after a cold wake (alarm is the only entry point that never called `setName()`)
- Real-world impact: `Agent.runWorkflow()` reads `this.name` to inject `__agentName` — crashes when triggered by `this.schedule()`

## Test plan

- [x] New `AlarmNameServer` test DO with seed endpoint that writes name to storage without calling `setName()`, simulating cold wake
- [x] Test asserts `nameWasCold: true` (proving storage recovery path was exercised, not a warm instance no-op)
- [x] Test asserts `this.name` returns correct value inside `onAlarm()`
- [x] All 33 existing tests pass