### PR TITLE
Persist room name to DO storage

### DIFF
--- a/.changeset/persist-room-name-alarm.md
+++ b/.changeset/persist-room-name-alarm.md
@@ -1,0 +1,5 @@
+---
+"partyserver": patch
+---
+
+`this.name` now works in `onAlarm()` for servers that have been fetched at least once.

--- a/packages/partyserver/src/tests/worker.ts
+++ b/packages/partyserver/src/tests/worker.ts
@@ -13,6 +13,7 @@ export type Env = {
   OnStartServer: DurableObjectNamespace<OnStartServer>;
   HibernatingOnStartServer: DurableObjectNamespace<HibernatingOnStartServer>;
   AlarmServer: DurableObjectNamespace<AlarmServer>;
+  AlarmNameServer: DurableObjectNamespace<AlarmNameServer>;
   Mixed: DurableObjectNamespace<Mixed>;
   ConfigurableState: DurableObjectNamespace<ConfigurableState>;
   ConfigurableStateInMemory: DurableObjectNamespace<ConfigurableStateInMemory>;
@@ -349,6 +350,22 @@ export class TagsServerInMemory extends Server {
 
   onConnect(connection: Connection): void {
     connection.send(JSON.stringify(connection.tags));
+  }
+}
+
+/**
+ * Tests that this.name is available in onAlarm after an alarm-triggered
+ * cold start (no prior fetch).
+ */
+export class AlarmNameServer extends Server {
+  static options = {
+    hibernate: true
+  };
+
+  alarmName: string | null = null;
+
+  onAlarm() {
+    this.alarmName = this.name;
   }
 }
 

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -56,6 +56,10 @@
         "class_name": "FailingOnStartServer"
       },
       {
+        "name": "AlarmNameServer",
+        "class_name": "AlarmNameServer"
+      },
+      {
         "name": "HibernatingNameInMessage",
         "class_name": "HibernatingNameInMessage"
       },
@@ -84,6 +88,7 @@
         "HibernatingOnStartServer",
         "AlarmServer",
         "FailingOnStartServer",
+        "AlarmNameServer",
         "HibernatingNameInMessage",
         "TagsServer",
         "TagsServerInMemory"


### PR DESCRIPTION
Closes #32.

**What**:

This PR allows alarm cold starts to access the room name.

**Why**:

This removes a footgun (I hit this today)

**How**:

`setName()` writes the name to storage under `__partyserver_name`. `#initialize()` restores it before `onStart()` if the name isn't set. (IIUC, only alarms will hit this code path.) `fetch()` also validates that an incoming `x-partykit-room` header matches the stored name. 

**Note**:

I considered allowing `fetch` to restore the room name from storage if `x-partykit-room` was unset. But that would be a bigger deviation from the current behavior than necessary to close #32. If there any code for like moving DOs between rooms, this PR will obviously break that, but I couldn't find any such code.

I couldn't find a way to make a durable object cold start in the tests, so I couldn't directly add a test for the intended functionality. However, I did add a test that the `__partyserver_name` field gets set, and that alarms work when that field gets set. The tests fail without this fix and pass with it.

Disclaimer: I used LLM assistance to create this PR. I've reviewed the code of course. This PR description is written by me. (I might seem LLM-ey but I just talk like this)