### PR TITLE
fix: persist Server.name to durable storage for alarm/cold-start hydration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@partyserver/fixture-*"]
+  "ignore": ["@partyserver/fixture-*"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/persist-server-name.md
+++ b/.changeset/persist-server-name.md
@@ -1,0 +1,5 @@
+---
+"partyserver": minor
+---
+
+Persist `Server.name` to durable storage so it survives cold starts without an HTTP request. Fixes `this.name` throwing inside `onAlarm()` and scheduled callbacks (cloudflare/agents#933).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12235,12 +12235,12 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "hono": "^4.11.1",
-        "partyserver": "^0.2.0"
+        "partyserver": ">=0.2.0 <1.0.0"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
         "hono": "^4.6.17",
-        "partyserver": "^0.2.0"
+        "partyserver": ">=0.2.0 <1.0.0"
       }
     },
     "packages/partyagent": {
@@ -12260,7 +12260,7 @@
       "license": "ISC",
       "dependencies": {
         "nanoid": "^5.1.6",
-        "partysocket": "^1.1.13"
+        "partysocket": "^1.1.14"
       }
     },
     "packages/partyhard": {
@@ -12327,12 +12327,12 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.2.0",
+        "partyserver": ">=0.2.0 <1.0.0",
         "partysocket": "^1.1.14"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
-        "partyserver": "^0.2.0",
+        "partyserver": ">=0.2.0 <1.0.0",
         "partysocket": "^1.1.14"
       }
     },
@@ -12345,11 +12345,11 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
-        "partyserver": "^0.2.0"
+        "partyserver": ">=0.2.0 <1.0.0"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
-        "partyserver": "^0.2.0"
+        "partyserver": ">=0.2.0 <1.0.0"
       }
     },
     "packages/partytracks": {
@@ -12367,7 +12367,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.4.0",
-        "partyserver": "^0.2.0"
+        "partyserver": ">=0.2.0 <1.0.0"
       }
     },
     "packages/y-partyserver": {
@@ -12382,13 +12382,13 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20251218.0",
         "@types/lodash.debounce": "^4.0.9",
-        "partyserver": "^0.2.0",
+        "partyserver": ">=0.2.0 <1.0.0",
         "ws": "^8.18.3",
         "yjs": "^13.6.28"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
-        "partyserver": "^0.2.0",
+        "partyserver": ">=0.2.0 <1.0.0",
         "yjs": "^13.6.14"
       }
     },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -32,11 +32,11 @@
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",
     "hono": "^4.6.17",
-    "partyserver": "^0.2.0"
+    "partyserver": ">=0.2.0 <1.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "hono": "^4.11.1",
-    "partyserver": "^0.2.0"
+    "partyserver": ">=0.2.0 <1.0.0"
   }
 }

--- a/packages/partyfn/package.json
+++ b/packages/partyfn/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "nanoid": "^5.1.6",
-    "partysocket": "^1.1.13"
+    "partysocket": "^1.1.14"
   },
   "scripts": {
     "build": "tsx scripts/build.ts"

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "main": "/worker.ts",
-  "compatibility_date": "2024-05-12",
+  "compatibility_date": "2026-01-28",
   "compatibility_flags": [
     "nodejs_compat",
     // test specific flags
@@ -52,6 +52,14 @@
         "class_name": "AlarmServer"
       },
       {
+        "name": "AlarmNameServer",
+        "class_name": "AlarmNameServer"
+      },
+      {
+        "name": "NoNameServer",
+        "class_name": "NoNameServer"
+      },
+      {
         "name": "FailingOnStartServer",
         "class_name": "FailingOnStartServer"
       },
@@ -72,7 +80,7 @@
   "migrations": [
     {
       "tag": "v1",
-      "new_classes": [
+      "new_sqlite_classes": [
         "Stateful",
         "OnStartServer",
         "Mixed",
@@ -83,6 +91,8 @@
         "CustomCorsServer",
         "HibernatingOnStartServer",
         "AlarmServer",
+        "AlarmNameServer",
+        "NoNameServer",
         "FailingOnStartServer",
         "HibernatingNameInMessage",
         "TagsServer",

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -41,12 +41,12 @@
   "description": "",
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",
-    "partyserver": "^0.2.0",
+    "partyserver": ">=0.2.0 <1.0.0",
     "partysocket": "^1.1.14"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.2.0",
+    "partyserver": ">=0.2.0 <1.0.0",
     "partysocket": "^1.1.14"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -50,10 +50,10 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",
-    "partyserver": "^0.2.0"
+    "partyserver": ">=0.2.0 <1.0.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
-    "partyserver": "^0.2.0"
+    "partyserver": ">=0.2.0 <1.0.0"
   }
 }

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.4.0",
-    "partyserver": "^0.2.0"
+    "partyserver": ">=0.2.0 <1.0.0"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -47,13 +47,13 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",
-    "partyserver": "^0.2.0",
+    "partyserver": ">=0.2.0 <1.0.0",
     "yjs": "^13.6.14"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20251218.0",
     "@types/lodash.debounce": "^4.0.9",
-    "partyserver": "^0.2.0",
+    "partyserver": ">=0.2.0 <1.0.0",
     "ws": "^8.18.3",
     "yjs": "^13.6.28"
   }


### PR DESCRIPTION
## Summary

`this.name` throws when accessed inside `onAlarm()` or scheduled callbacks because alarms are the only Durable Object entry point that never receives an HTTP request — and partyserver's name was only set from the `x-partykit-room` request header.

This PR persists the name to `ctx.storage.kv` (synchronous DO storage) on `setName()` and hydrates it lazily in the `name` getter. This makes `this.name` work in **every** context — alarms, WebSocket hibernation wake-ups, direct `stub.fetch()` without the header, and any future entry point.

Fixes cloudflare/agents#933. Supersedes #331 with a more comprehensive approach.

## What changed

### Core fix: name persistence (`packages/partyserver/src/index.ts`)

- **`setName()`** now persists the name to `ctx.storage.kv.put("__ps_name", name)` synchronously alongside setting `#_name`.
- **`name` getter** hydrates from `ctx.storage.kv.get("__ps_name")` before throwing, so the name is available on any cold start where it was previously persisted.
- **Removed `#_longErrorAboutNameThrown`** — the dedup flag is no longer needed since the getter now falls back to storage before erroring.

### Cleanup: consolidated initialization

- **Renamed `#initialize()` → `#ensureInitialized()`** with an early `if (this.#status === "started") return` guard, making it idempotent. Eliminated 4 separate `if (this.#status !== "started")` checks across `fetch()`, `setName()`, `alarm()`, and the WS handlers.

### Cleanup: decoupled name from WS handlers

- **`webSocketMessage`/`Close`/`Error`** no longer call `setName(connection.server)`. They call `#ensureInitialized()` instead. The name is handled by the getter's storage hydration, not by reading it from the per-connection WebSocket attachment. This resolves the `// TODO: this shouldn't be async` comments on all three handlers.

### Cleanup: `fetch()` storage fallback

- **`fetch()` now tries storage before requiring the header.** On cold start, if the name was previously persisted, the `x-partykit-room` header is no longer required. The header is only needed on first-ever contact with a DO. This means direct `stub.fetch()` calls work for previously-initialized DOs.
- Removed stale comments referencing workerd#2240 as "temporary".

### Dependency range widening

- Widened `partyserver` dependency ranges in `hono-party`, `partysub`, `partysync`, `y-partyserver`, and `partywhen` from `^0.2.0` (which means `>=0.2.0 <0.3.0` in 0.x semver) to `>=0.2.0 <1.0.0` so a minor bump doesn't cascade into major bumps on all dependents.
- Added `onlyUpdatePeerDependentsWhenOutOfRange` to changeset config to prevent unnecessary major cascades for 0.x packages.

## How it works

```
┌─────────────────────────────────────────────────────────┐
│ setName("my-room")                                      │
│   1. this.#_name = "my-room"                            │
│   2. ctx.storage.kv.put("__ps_name", "my-room")  [sync] │
│   3. #ensureInitialized() → onStart()                   │
└─────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────┐
│ get name() — on any cold start                          │
│   1. #_name is undefined                                │
│   2. ctx.storage.kv.get("__ps_name")              [sync] │
│   3. Found → cache in #_name, return                    │
│   4. Not found → throw (name was never set)             │
└─────────────────────────────────────────────────────────┘
```

## Comparison with #331

| | #331 | This PR |
|---|---|---|
| Storage API | `await ctx.storage.put/get` (async) | `ctx.storage.kv.put/get` (sync) |
| Where name hydrates | Only in `alarm()` | In the `name` getter — all entry points |
| `fetch()` header | Still always required | Falls back to storage for returning DOs |
| WS handlers | Unchanged (`setName(connection.server)`) | Simplified to `#ensureInitialized()` |
| Init guards | 4 separate `if (#status)` checks | Single idempotent `#ensureInitialized()` |

## Test plan

8 new tests added (40 total, up from 32):

- [x] `persists name to storage when setName is called` — basic write path
- [x] `this.name is available inside onAlarm after normal setup` — warm alarm
- [x] `hydrates name from storage on cold alarm wake (bypassing setName)` — seeds storage directly without calling setName, proving the getter's KV read is the recovery mechanism
- [x] `this.name is available inside onStart during alarm wake` — critical for Agent's MCP restoration
- [x] `fetch() hydrates name from storage without requiring the header` — direct stub.fetch works for returning DOs
- [x] `setName is idempotent for the same value` — no throw on repeated calls
- [x] `throws when name was never set and is not in storage` — brand-new DOs still error correctly
- [x] `getServerByName persists the name for future access` — name set via routing is available on subsequent headerless fetches

All 40 tests pass.

Made with [Cursor](https://cursor.com)