### PR TITLE
Declare React as an optional peer dependency of partysocket

### DIFF
--- a/.changeset/react-peer-dep.md
+++ b/.changeset/react-peer-dep.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+Declare `react` as an optional peer dependency so strict package managers like pnpm correctly resolve it for the `partysocket/react` and `partysocket/use-ws` subpath exports.

--- a/fixtures/hono/src/server.ts
+++ b/fixtures/hono/src/server.ts
@@ -21,7 +21,7 @@ app.use(
   "*",
   partyserverMiddleware<{ Bindings: Bindings }>({
     options: {
-      onBeforeConnect(req, lobby, c) {
+      onBeforeConnect(req, _lobby, c) {
         const url = new URL(req.url);
         const token = url.searchParams.get("token");
         if (!token) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12320,6 +12320,14 @@
       "devDependencies": {
         "@testing-library/react": "^16.3.1",
         "@types/ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "packages/partysub": {

--- a/packages/partysocket/package.json
+++ b/packages/partysocket/package.json
@@ -87,6 +87,14 @@
   "dependencies": {
     "event-target-polyfill": "^0.0.4"
   },
+  "peerDependencies": {
+    "react": ">=17"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@testing-library/react": "^16.3.1",
     "@types/ws": "^8.18.1"

--- a/packages/partysocket/src/tests/react-hooks.test.tsx
+++ b/packages/partysocket/src/tests/react-hooks.test.tsx
@@ -5,7 +5,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { afterAll, beforeAll, describe, expect, test, vitest } from "vitest";
-import { WebSocketServer } from "ws";
+import { type WebSocket as WsWebSocket, WebSocketServer } from "ws";
 
 import usePartySocket, { useWebSocket } from "../react";
 
@@ -320,7 +320,7 @@ describe.skipIf(!!process.env.GITHUB_ACTIONS)("usePartySocket", () => {
     const onOpen = vitest.fn();
 
     const connectionPromise = new Promise<void>((resolve) => {
-      wss.once("connection", (_ws: any) => {
+      wss.once("connection", (_ws: WsWebSocket) => {
         resolve();
       });
     });
@@ -355,7 +355,7 @@ describe.skipIf(!!process.env.GITHUB_ACTIONS)("usePartySocket", () => {
     const onMessage = vitest.fn();
     const testMessage = "hello from server";
 
-    const connectionHandler = (ws: any) => {
+    const connectionHandler = (ws: WsWebSocket) => {
       setTimeout(() => {
         ws.send(testMessage);
       }, 200);
@@ -453,7 +453,7 @@ describe.skipIf(!!process.env.GITHUB_ACTIONS)("usePartySocket", () => {
       const onMessage1 = vitest.fn();
       const onMessage2 = vitest.fn();
 
-      const connectionHandler = (ws: any) => {
+      const connectionHandler = (ws: WsWebSocket) => {
         setTimeout(() => ws.send("message1"), 100);
         setTimeout(() => ws.send("message2"), 200);
       };

--- a/packages/partysocket/src/use-socket.ts
+++ b/packages/partysocket/src/use-socket.ts
@@ -43,8 +43,12 @@ export function useStableSocket<
   // extract enabled with default value of true
   const { enabled = true } = options;
 
-  // ensure we only reconnect when necessary
+  // Returns a stable reference to options, only updating when the serialized
+  // key changes. This avoids reconnecting on every render when callers pass
+  // an inline options object (new reference each time) whose values haven't
+  // actually changed.
   const shouldReconnect = createOptionsMemoKey(options);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: shouldReconnect is a serialized key derived from options — we intentionally memo on the key, not the object reference
   const socketOptions = useMemo(() => {
     return options;
   }, [shouldReconnect]);


### PR DESCRIPTION
## Summary

Fixes https://github.com/cloudflare/partykit/issues/292

- Declares `react` as an optional peer dependency (`>=17`) in `partysocket`, so strict package managers like pnpm correctly resolve it for the `partysocket/react` and `partysocket/use-ws` subpath exports. Marked optional so users who only use the core WebSocket client aren't required to install React.
- Fixes pre-existing lint errors: replaces `any` with proper `WsWebSocket` type in tests, prefixes unused param with `_`, and adds a `biome-ignore` for the intentional `useMemo` dependency pattern in `use-socket.ts`.

## Test plan

- [x] `npm run check` passes (sherif, prettier, biome, typecheck, all test suites)
- [ ] Verify in a pnpm monorepo that `partysocket/react` resolves React correctly


Made with [Cursor](https://cursor.com)