### PR TITLE
Remove default logging from Server onConnect and onMessage

### DIFF
--- a/.changeset/remove-default-logging.md
+++ b/.changeset/remove-default-logging.md
@@ -1,0 +1,5 @@
+---
+"partyserver": patch
+---
+
+Remove default console.log/console.info calls from `onConnect` and `onMessage` base methods in `Server`

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -687,13 +687,14 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
    * Called when a new connection is made to the server.
    */
   onConnect(
+    // oxlint-disable-next-line no-unused-vars
     connection: Connection,
     // oxlint-disable-next-line no-unused-vars
     ctx: ConnectionContext
   ): void | Promise<void> {
-    console.log(
-      `Connection ${connection.id} connected to ${this.#ParentClass.name}:${this.name}`
-    );
+    // console.log(
+    //   `Connection ${connection.id} connected to ${this.#ParentClass.name}:${this.name}`
+    // );
     // console.log(
     //   `Implement onConnect on ${this.#ParentClass.name} to handle websocket connections.`
     // );
@@ -704,12 +705,12 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
    */
   // oxlint-disable-next-line no-unused-vars
   onMessage(connection: Connection, message: WSMessage): void | Promise<void> {
-    console.log(
-      `Received message on connection ${this.#ParentClass.name}:${connection.id}`
-    );
-    console.info(
-      `Implement onMessage on ${this.#ParentClass.name} to handle this message.`
-    );
+    // console.log(
+    //   `Received message on connection ${this.#ParentClass.name}:${connection.id}`
+    // );
+    // console.info(
+    //   `Implement onMessage on ${this.#ParentClass.name} to handle this message.`
+    // );
   }
 
   /**

--- a/packages/y-partyserver/CHANGELOG.md
+++ b/packages/y-partyserver/CHANGELOG.md
@@ -19,7 +19,6 @@
 - [#341](https://github.com/cloudflare/partykit/pull/341) [`e7f4b51`](https://github.com/cloudflare/partykit/commit/e7f4b51198904273befb1d39478840c628f6e2b1) Thanks [@threepointone](https://github.com/threepointone)! - Fix Yjs hibernation support and awareness propagation
 
   **Server:**
-
   - Replace in-memory `WSSharedDoc.conns` Map with `connection.setState()` and `getConnections()` so connection tracking survives Durable Object hibernation
   - Move event handler registration from `WSSharedDoc` constructor into `onStart()` to use `getConnections()` for broadcasting
   - Disable awareness protocol's built-in `_checkInterval` in `WSSharedDoc` constructor to prevent timers from defeating hibernation
@@ -29,7 +28,6 @@
   - Widen `onLoad()` return type to `Promise<YDoc | void>` to allow seeding the document from a returned YDoc
 
   **Provider:**
-
   - Switch awareness event listener from `"update"` to `"change"` so clock-only heartbeat renewals do not produce network traffic (allows DO hibernation during idle sessions)
   - Disable awareness protocol's built-in `_checkInterval` on the client to stop 15-second clock renewals and 30-second peer timeout removal
   - Remove provider's own `_checkInterval` liveness timer (was coupled to the awareness heartbeat)
@@ -364,14 +362,12 @@
 ### Patch Changes
 
 - [`528adea`](https://github.com/threepointone/partyserver/commit/528adeaced6dce6e888d2f54cc75c3569bf2c277) Thanks [@threepointone](https://github.com/threepointone)! - some fixes and tweaks
-
   - getServerByName was throwing on all requests
   - `Env` is now an optional arg when defining `Server`
   - `y-partyserver/provider` can now take an optional `prefix` arg to use a custom url to connect
   - `routePartyKitRequest`/`getServerByName` now accepts `jurisdiction`
 
   bonus:
-
   - added a bunch of fixtures
   - added stubs for docs
 


### PR DESCRIPTION
Remove default `console.log`/`console.info` calls from the base `onConnect` and `onMessage` methods in `Server`. These log messages are noisy for users who haven't yet implemented their own handlers and don't provide actionable information.