### PR TITLE
Use RPC instead of HTTP headers for DO initialization

### DIFF
--- a/.changeset/use-rpc-for-init.md
+++ b/.changeset/use-rpc-for-init.md
@@ -1,0 +1,10 @@
+---
+"partyserver": patch
+---
+
+Use RPC instead of HTTP headers to pass room name and props to Durable Objects, preventing sensitive information from appearing in logs.
+
+- `getServerByName` now calls `stub.setName()` via RPC instead of sending a dummy fetch request with headers.
+- `routePartykitRequest` uses a new internal `_initAndFetch` RPC method for HTTP requests (single round trip), and `setName` + `fetch` for WebSocket upgrades.
+- `setName` accepts an optional `props` parameter and short-circuits when the name is already set.
+- Removed the `/cdn-cgi/partyserver/set-name/` internal endpoint (no longer needed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,6 +413,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1271,6 +1272,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1311,6 +1313,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1813,6 +1816,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
@@ -2898,6 +2902,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6310,6 +6315,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.0.tgz",
       "integrity": "sha512-aC9aROgia/SpJqhsXFiX9TsligL8d+oeoI8W3u00WI45s0VfsqjgeKQLDLF7Tu7hC+7F02teC84SAHuup003VQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6561,6 +6567,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.0.tgz",
       "integrity": "sha512-+V0/gsVWAv+7vcY0MAe6D52LYTIicMSHw00wz3ISZgprSb2yQhJ4+4gurOnUrQ4Du3AnRQvxPROaofwxIQ66WQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6666,6 +6673,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.0.tgz",
       "integrity": "sha512-HIsXX942w3nbxEQBlMAAR/aa6qiMBEP7CsSMxaxmTIVAmW35p6yUASw6GdV1u0o3lCZjXq2OSRMTskzIqi5uLg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6680,6 +6688,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.0.tgz",
       "integrity": "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -6912,8 +6921,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7046,6 +7054,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7055,6 +7064,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7184,6 +7194,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -7199,6 +7210,7 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -7285,7 +7297,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7327,7 +7338,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -7513,6 +7523,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7847,7 +7858,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7896,8 +7906,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -8777,6 +8786,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9394,6 +9404,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -9962,7 +9973,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10093,6 +10103,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
       "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10122,6 +10133,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10170,6 +10182,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -10390,6 +10403,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10399,6 +10413,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10420,8 +10435,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10622,6 +10636,7 @@
       "integrity": "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.112.0",
         "@rolldown/pluginutils": "1.0.0-rc.3"
@@ -11419,6 +11434,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11644,6 +11660,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11684,6 +11701,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11759,6 +11777,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -11944,6 +11963,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12073,6 +12093,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12086,6 +12107,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12267,6 +12289,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -12388,6 +12411,7 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
       "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -12415,6 +12439,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
       "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },

--- a/packages/partyserver/CHANGELOG.md
+++ b/packages/partyserver/CHANGELOG.md
@@ -306,14 +306,12 @@
 ### Patch Changes
 
 - [`528adea`](https://github.com/threepointone/partyserver/commit/528adeaced6dce6e888d2f54cc75c3569bf2c277) Thanks [@threepointone](https://github.com/threepointone)! - some fixes and tweaks
-
   - getServerByName was throwing on all requests
   - `Env` is now an optional arg when defining `Server`
   - `y-partyserver/provider` can now take an optional `prefix` arg to use a custom url to connect
   - `routePartyKitRequest`/`getServerByName` now accepts `jurisdiction`
 
   bonus:
-
   - added a bunch of fixtures
   - added stubs for docs
 

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -55,20 +55,7 @@ export async function getServerByName<
   const id = serverNamespace.idFromName(name);
   const stub = serverNamespace.get(id, options);
 
-  // TODO: fix this to use RPC
-
-  const req = new Request(
-    "http://dummy-example.cloudflare.com/cdn-cgi/partyserver/set-name/"
-  );
-
-  req.headers.set("x-partykit-room", name);
-
-  if (options?.props) {
-    req.headers.set("x-partykit-props", JSON.stringify(options?.props));
-  }
-
-  // unfortunately we have to await this
-  await stub.fetch(req).then((res) => res.text());
+  await stub.setName(name, options?.props);
 
   return stub;
 }
@@ -267,14 +254,9 @@ Did you forget to add a durable object binding to the class ${namespace[0].toUpp
     const stub = doNamespace.get(id, options);
 
     req = new Request(req);
-    req.headers.set("x-partykit-room", name);
     req.headers.set("x-partykit-namespace", namespace);
     if (options?.jurisdiction) {
       req.headers.set("x-partykit-jurisdiction", options.jurisdiction);
-    }
-
-    if (options?.props) {
-      req.headers.set("x-partykit-props", JSON.stringify(options?.props));
     }
 
     const className = bindingNames[namespace] as Extract<keyof Env, string>;
@@ -315,7 +297,11 @@ Did you forget to add a durable object binding to the class ${namespace[0].toUpp
       }
     }
 
-    return withCorsHeaders(await stub.fetch(req));
+    if (isWebSocket) {
+      await stub.setName(name, options?.props);
+      return await stub.fetch(req);
+    }
+    return withCorsHeaders(await stub._initAndFetch(name, options?.props, req));
   } else {
     return null;
   }
@@ -399,10 +385,6 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
       await this.#ensureInitialized();
 
       const url = new URL(request.url);
-
-      if (url.pathname === "/cdn-cgi/partyserver/set-name/") {
-        return Response.json({ ok: true });
-      }
 
       if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
         return await this.onRequest(request);
@@ -623,7 +605,7 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
     return this.#_name;
   }
 
-  async setName(name: string) {
+  async setName(name: string, props?: Props) {
     if (!name) {
       throw new Error("A name is required.");
     }
@@ -632,10 +614,40 @@ Did you try connecting directly to this Durable Object? Try using getServerByNam
         `This server already has a name: ${this.#_name}, attempting to set to: ${name}`
       );
     }
+    if (props !== undefined) {
+      this.#_props = props;
+    }
+    if (this.#_name === name) {
+      return;
+    }
     this.#_name = name;
     await this.ctx.storage.put(NAME_STORAGE_KEY, name);
 
     await this.#ensureInitialized();
+  }
+
+  /**
+   * @internal Sets name/props and handles a request in a single RPC call.
+   * Used by routePartykitRequest to avoid an extra round trip.
+   */
+  async _initAndFetch(
+    name: string,
+    props: Props | undefined,
+    request: Request
+  ): Promise<Response> {
+    if (props !== undefined) {
+      this.#_props = props;
+    }
+    if (this.#_name && this.#_name !== name) {
+      throw new Error(
+        `This server already has a name: ${this.#_name}, attempting to set to: ${name}`
+      );
+    }
+    if (!this.#_name) {
+      this.#_name = name;
+      await this.ctx.storage.put(NAME_STORAGE_KEY, name);
+    }
+    return this.fetch(request);
   }
 
   #sendMessageToConnection(connection: Connection, message: WSMessage): void {

--- a/packages/partyserver/src/tests/index.test.ts
+++ b/packages/partyserver/src/tests/index.test.ts
@@ -1063,3 +1063,62 @@ describe("Connection uri", () => {
     return promise;
   });
 });
+
+describe("Props via RPC (_initAndFetch)", () => {
+  it("delivers props to onStart via HTTP request", async () => {
+    const ctx = createExecutionContext();
+    const request = new Request(
+      "http://example.com/props-parties/props-server/room1"
+    );
+    const response = await worker.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      name: string;
+      props: { secret: string };
+    };
+    expect(data.name).toBe("room1");
+    expect(data.props).toEqual({ secret: "my-secret-value" });
+  });
+
+  it("delivers props to onStart via WebSocket connection", async () => {
+    const ctx = createExecutionContext();
+    const request = new Request(
+      "http://example.com/props-parties/props-server/room2",
+      {
+        headers: { Upgrade: "websocket" }
+      }
+    );
+    const response = await worker.fetch(request, env, ctx);
+    const ws = response.webSocket!;
+    ws.accept();
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    ws.addEventListener("message", (message) => {
+      try {
+        const data = JSON.parse(message.data as string) as {
+          name: string;
+          props: { secret: string };
+        };
+        expect(data.name).toBe("room2");
+        expect(data.props).toEqual({ secret: "my-secret-value" });
+        resolve();
+      } catch (e) {
+        reject(e);
+      } finally {
+        ws.close();
+      }
+    });
+
+    return promise;
+  });
+
+  it("does not leak props in request headers", async () => {
+    const ctx = createExecutionContext();
+    const request = new Request(
+      "http://example.com/props-parties/props-server/room3"
+    );
+    const response = await worker.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    expect(request.headers.get("x-partykit-props")).toBeNull();
+  });
+});

--- a/packages/partyserver/src/tests/worker.ts
+++ b/packages/partyserver/src/tests/worker.ts
@@ -27,6 +27,7 @@ export type Env = {
   TagsServerInMemory: DurableObjectNamespace<TagsServerInMemory>;
   UriServer: DurableObjectNamespace<UriServer>;
   UriServerInMemory: DurableObjectNamespace<UriServerInMemory>;
+  PropsServer: DurableObjectNamespace<PropsServer>;
 };
 
 export class Stateful extends Server {
@@ -460,6 +461,27 @@ export class UriServerInMemory extends Server {
   }
 }
 
+export class PropsServer extends Server<Env, { secret: string }> {
+  receivedProps: { secret: string } | undefined;
+
+  onStart(props?: { secret: string }) {
+    this.receivedProps = props;
+  }
+
+  onRequest(): Response {
+    return Response.json({
+      name: this.name,
+      props: this.receivedProps
+    });
+  }
+
+  onConnect(connection: Connection): void {
+    connection.send(
+      JSON.stringify({ name: this.name, props: this.receivedProps })
+    );
+  }
+}
+
 export class CorsServer extends Server {
   onRequest(): Response | Promise<Response> {
     return Response.json({ cors: true });
@@ -475,6 +497,16 @@ export class CustomCorsServer extends Server {
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext) {
     const url = new URL(request.url);
+
+    // Route requests under /props-parties/ with props
+    if (url.pathname.startsWith("/props-parties/")) {
+      return (
+        (await routePartykitRequest(request, env, {
+          prefix: "props-parties",
+          props: { secret: "my-secret-value" }
+        })) || new Response("Not Found", { status: 404 })
+      );
+    }
 
     // Route requests under /cors-parties/ with cors: true
     if (url.pathname.startsWith("/cors-parties/")) {

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -82,6 +82,10 @@
       {
         "name": "UriServerInMemory",
         "class_name": "UriServerInMemory"
+      },
+      {
+        "name": "PropsServer",
+        "class_name": "PropsServer"
       }
     ]
   },
@@ -106,7 +110,8 @@
         "TagsServer",
         "TagsServerInMemory",
         "UriServer",
-        "UriServerInMemory"
+        "UriServerInMemory",
+        "PropsServer"
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- Replaces the pattern of passing room name and props via HTTP headers (`x-partykit-room`, `x-partykit-props`) with Durable Object RPC calls, preventing sensitive information from appearing in request logs.
- `getServerByName` now calls `stub.setName(name, props)` directly instead of constructing a dummy fetch request.
- `routePartykitRequest` uses a new internal `_initAndFetch` RPC method for HTTP requests (single round trip), and `setName` + `stub.fetch()` for WebSocket upgrades (since WebSocket upgrade responses can't be serialized through RPC).
- `setName` accepts an optional `props` parameter and short-circuits when the name is already set.
- Removes the `/cdn-cgi/partyserver/set-name/` internal endpoint (no longer needed).
- Adds tests verifying props flow correctly through the RPC path.

## Test plan

- [x] All 48 existing + new tests pass (`npm run check:test` in `packages/partyserver`)
- [x] Props delivered to `onStart` via HTTP requests
- [x] Props delivered to `onStart` via WebSocket connections
- [x] Props not leaked in request headers


Made with [Cursor](https://cursor.com)