### PR TITLE
Fix: re-evaluate params() on WebSocket reconnect

### DIFF
--- a/.changeset/fix-params-reconnect.md
+++ b/.changeset/fix-params-reconnect.md
@@ -1,0 +1,9 @@
+---
+"y-partyserver": patch
+---
+
+Fix params() not being re-evaluated on WebSocket reconnect
+
+When `params` was passed as a function to `YProvider`, it was only evaluated on the initial connection. On automatic reconnects (e.g. after a network drop), the params function was not called again, causing dynamic values like auth tokens to go stale.
+
+The reconnection path now goes through an overridable `_reconnectWS()` method that `YProvider` uses to re-resolve params before re-establishing the WebSocket.

--- a/package-lock.json
+++ b/package-lock.json
@@ -413,6 +413,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1271,6 +1272,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1311,6 +1313,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1813,6 +1816,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
       "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
@@ -2898,6 +2902,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6310,6 +6315,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.20.0.tgz",
       "integrity": "sha512-aC9aROgia/SpJqhsXFiX9TsligL8d+oeoI8W3u00WI45s0VfsqjgeKQLDLF7Tu7hC+7F02teC84SAHuup003VQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6561,6 +6567,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.20.0.tgz",
       "integrity": "sha512-+V0/gsVWAv+7vcY0MAe6D52LYTIicMSHw00wz3ISZgprSb2yQhJ4+4gurOnUrQ4Du3AnRQvxPROaofwxIQ66WQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6666,6 +6673,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.20.0.tgz",
       "integrity": "sha512-HIsXX942w3nbxEQBlMAAR/aa6qiMBEP7CsSMxaxmTIVAmW35p6yUASw6GdV1u0o3lCZjXq2OSRMTskzIqi5uLg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6680,6 +6688,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.20.0.tgz",
       "integrity": "sha512-jn+2KnQZn+b+VXr8EFOJKsnjVNaA4diAEr6FOazupMt8W8ro1hfpYtZ25JL87Kao/WbMze55sd8M8BDXLUKu1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -6912,8 +6921,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -7046,6 +7054,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7055,6 +7064,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7184,6 +7194,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -7199,6 +7210,7 @@
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -7285,7 +7297,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7327,7 +7338,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -7513,6 +7523,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7847,7 +7858,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7896,8 +7906,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
@@ -8777,6 +8786,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -9394,6 +9404,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -9962,7 +9973,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10093,6 +10103,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.22.2.tgz",
       "integrity": "sha512-I4lS7HHIW47D0Xv/gWmi4iUWcQIDYaJKd8Hk4+lcSps+553FlQrhmxtItpEvTr75iAruhzVShVp6WUwsT6Boww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -10122,6 +10133,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -10170,6 +10182,7 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -10390,6 +10403,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10399,6 +10413,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10420,8 +10435,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -10622,6 +10636,7 @@
       "integrity": "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.112.0",
         "@rolldown/pluginutils": "1.0.0-rc.3"
@@ -11419,6 +11434,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11644,6 +11660,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -11684,6 +11701,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11759,6 +11777,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -11944,6 +11963,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12073,6 +12093,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12086,6 +12107,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12267,6 +12289,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -12388,6 +12411,7 @@
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
       "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.85"
       },
@@ -12415,6 +12439,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
       "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -12481,7 +12506,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260303.0",
         "hono": "^4.12.2",
-        "partyserver": "^0.4.0"
+        "partyserver": "^0.4.1"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20240729.0",
@@ -12618,7 +12643,7 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260303.0",
-        "partyserver": "^0.4.0",
+        "partyserver": "^0.4.1",
         "partysocket": "^1.1.16"
       },
       "peerDependencies": {
@@ -12637,7 +12662,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260303.0",
         "partyfn": "^0.1.0",
-        "partyserver": "^0.4.0",
+        "partyserver": "^0.4.1",
         "partysocket": "^1.1.16"
       },
       "peerDependencies": {
@@ -12680,7 +12705,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.5.0",
-        "partyserver": "^0.4.0"
+        "partyserver": "^0.4.1"
       }
     },
     "packages/y-partyserver": {
@@ -12695,7 +12720,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260303.0",
         "@types/lodash.debounce": "^4.0.9",
-        "partyserver": "^0.4.0",
+        "partyserver": "^0.4.1",
         "ws": "^8.19.0",
         "yjs": "^13.6.29"
       },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260303.0",
     "hono": "^4.12.2",
-    "partyserver": "^0.4.0"
+    "partyserver": "^0.4.1"
   }
 }

--- a/packages/partyserver/CHANGELOG.md
+++ b/packages/partyserver/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - [#365](https://github.com/cloudflare/partykit/pull/365) [`3fba690`](https://github.com/cloudflare/partykit/commit/3fba6903ec67cf902841fdd8080139cb0c26ada8) Thanks [@threepointone](https://github.com/threepointone)! - Use RPC instead of HTTP headers to pass room name and props to Durable Objects, preventing sensitive information from appearing in logs.
-
   - `getServerByName` now calls `stub.setName()` via RPC instead of sending a dummy fetch request with headers.
   - `routePartykitRequest` uses a new internal `_initAndFetch` RPC method for HTTP requests (single round trip), and `setName` + `fetch` for WebSocket upgrades.
   - `setName` accepts an optional `props` parameter and short-circuits when the name is already set.
@@ -317,14 +316,12 @@
 ### Patch Changes
 
 - [`528adea`](https://github.com/threepointone/partyserver/commit/528adeaced6dce6e888d2f54cc75c3569bf2c277) Thanks [@threepointone](https://github.com/threepointone)! - some fixes and tweaks
-
   - getServerByName was throwing on all requests
   - `Env` is now an optional arg when defining `Server`
   - `y-partyserver/provider` can now take an optional `prefix` arg to use a custom url to connect
   - `routePartyKitRequest`/`getServerByName` now accepts `jurisdiction`
 
   bonus:
-
   - added a bunch of fixtures
   - added stubs for docs
 

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260303.0",
-    "partyserver": "^0.4.0",
+    "partyserver": "^0.4.1",
     "partysocket": "^1.1.16"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260303.0",
     "partyfn": "^0.1.0",
-    "partyserver": "^0.4.0",
+    "partyserver": "^0.4.1",
     "partysocket": "^1.1.16"
   },
   "peerDependencies": {

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.5.0",
-    "partyserver": "^0.4.0"
+    "partyserver": "^0.4.1"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260303.0",
     "@types/lodash.debounce": "^4.0.9",
-    "partyserver": "^0.4.0",
+    "partyserver": "^0.4.1",
     "ws": "^8.19.0",
     "yjs": "^13.6.29"
   },

--- a/packages/y-partyserver/src/provider/index.ts
+++ b/packages/y-partyserver/src/provider/index.ts
@@ -180,12 +180,17 @@ function setupWS(provider: WebsocketProvider) {
       // Start with no reconnect timeout and increase timeout by
       // using exponential backoff starting with 100ms
       setTimeout(
-        setupWS,
+        () => {
+          if (provider.shouldConnect) {
+            Promise.resolve(provider._reconnectWS()).catch((err) => {
+              console.error("Reconnection failed", err);
+            });
+          }
+        },
         math.min(
           math.pow(2, provider.wsUnsuccessfulReconnects) * 100,
           provider.maxBackoffTime
-        ),
-        provider
+        )
       );
     });
     websocket.addEventListener("open", () => {
@@ -522,6 +527,15 @@ export class WebsocketProvider extends Observable<string> {
     }
   }
 
+  /**
+   * Called by the close handler to re-establish the WebSocket.
+   * Subclasses (e.g. YProvider) override this to refresh dynamic
+   * params before reconnecting.
+   */
+  _reconnectWS() {
+    setupWS(this);
+  }
+
   connect() {
     this.shouldConnect = true;
     if (!this.wsconnected && this.ws === null) {
@@ -608,34 +622,42 @@ export default class YProvider extends WebsocketProvider {
     }
   }
 
-  async connect() {
-    try {
-      // get updated url parameters
-      const nextParams =
-        typeof this.#params === "function"
-          ? await this.#params()
-          : this.#params;
-      // override current url parameters before connecting
-      const urlParams = new URLSearchParams([["_pk", this.id]]);
-      if (nextParams) {
-        for (const [key, value] of Object.entries(nextParams)) {
-          // filter out null/undefined values
-          if (value !== null && value !== undefined) {
-            urlParams.append(key, value);
-          }
+  async #resolveParams() {
+    const nextParams =
+      typeof this.#params === "function" ? await this.#params() : this.#params;
+    const urlParams = new URLSearchParams([["_pk", this.id]]);
+    if (nextParams) {
+      for (const [key, value] of Object.entries(nextParams)) {
+        if (value !== null && value !== undefined) {
+          urlParams.append(key, value);
         }
       }
+    }
+    const nextUrl = new URL(this.url);
+    nextUrl.search = urlParams.toString();
+    this.url = nextUrl.toString();
+  }
 
-      const nextUrl = new URL(this.url);
-      nextUrl.search = urlParams.toString();
-      this.url = nextUrl.toString();
-
-      // finally, connect
+  async connect() {
+    try {
+      await this.#resolveParams();
       super.connect();
     } catch (err) {
       console.error("Failed to open connecton to PartyServer", err);
       throw err;
     }
+  }
+
+  async _reconnectWS() {
+    try {
+      await this.#resolveParams();
+    } catch (err) {
+      console.error(
+        "Failed to refresh params, reconnecting with stale params",
+        err
+      );
+    }
+    super._reconnectWS();
   }
 
   sendMessage(message: string) {

--- a/packages/y-partyserver/src/tests/integration.test.ts
+++ b/packages/y-partyserver/src/tests/integration.test.ts
@@ -431,6 +431,166 @@ describe("Integration — onLoad returns YDoc", () => {
   });
 });
 
+describe("Integration — params re-evaluation on reconnect", () => {
+  it("re-evaluates params function on automatic reconnect", async () => {
+    const room = `params-reconnect-${Date.now()}`;
+
+    let callCount = 0;
+    const doc = new Y.Doc();
+    const provider = new YProvider(HOST, room, doc, {
+      party: "y-basic",
+      connect: true,
+      WebSocketPolyfill: WebSocket as unknown as typeof globalThis.WebSocket,
+      disableBc: true,
+      params: () => {
+        callCount++;
+        return { token: `token-${callCount}` };
+      }
+    });
+    providers.push(provider);
+
+    await waitForConnection(provider);
+    expect(callCount).toBe(1);
+    expect(provider.url).toContain("token-1");
+
+    // Force-close the WebSocket to trigger automatic reconnection.
+    // Unlike provider.disconnect(), this does not set shouldConnect=false,
+    // so the provider will auto-reconnect and re-evaluate params.
+    const ws = provider.ws as unknown as {
+      terminate?: () => void;
+      close: () => void;
+    };
+    if (ws && typeof ws.terminate === "function") {
+      ws.terminate();
+    } else if (ws) {
+      ws.close();
+    }
+
+    // Wait for the provider to auto-reconnect
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for reconnection")),
+        10000
+      );
+      const handler = (event: { status: string }) => {
+        if (event.status === "connected") {
+          clearTimeout(timeout);
+          provider.off("status", handler);
+          resolve();
+        }
+      };
+      provider.on("status", handler);
+    });
+
+    expect(callCount).toBe(2);
+    expect(provider.url).toContain("token-2");
+    expect(provider.url).not.toContain("token-1");
+  });
+
+  it("re-evaluates async params function on automatic reconnect", async () => {
+    const room = `params-async-reconnect-${Date.now()}`;
+
+    let callCount = 0;
+    const doc = new Y.Doc();
+    const provider = new YProvider(HOST, room, doc, {
+      party: "y-basic",
+      connect: true,
+      WebSocketPolyfill: WebSocket as unknown as typeof globalThis.WebSocket,
+      disableBc: true,
+      params: async () => {
+        callCount++;
+        return { token: `async-token-${callCount}` };
+      }
+    });
+    providers.push(provider);
+
+    await waitForConnection(provider);
+    expect(callCount).toBe(1);
+    expect(provider.url).toContain("async-token-1");
+
+    const ws = provider.ws as unknown as {
+      terminate?: () => void;
+      close: () => void;
+    };
+    if (ws && typeof ws.terminate === "function") {
+      ws.terminate();
+    } else if (ws) {
+      ws.close();
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Timed out waiting for reconnection")),
+        10000
+      );
+      const handler = (event: { status: string }) => {
+        if (event.status === "connected") {
+          clearTimeout(timeout);
+          provider.off("status", handler);
+          resolve();
+        }
+      };
+      provider.on("status", handler);
+    });
+
+    expect(callCount).toBe(2);
+    expect(provider.url).toContain("async-token-2");
+    expect(provider.url).not.toContain("async-token-1");
+  });
+
+  it("does not reconnect when user called disconnect()", async () => {
+    const room = `params-no-reconnect-${Date.now()}`;
+
+    let callCount = 0;
+    const doc = new Y.Doc();
+    const provider = new YProvider(HOST, room, doc, {
+      party: "y-basic",
+      connect: true,
+      WebSocketPolyfill: WebSocket as unknown as typeof globalThis.WebSocket,
+      disableBc: true,
+      params: () => {
+        callCount++;
+        return { token: `token-${callCount}` };
+      }
+    });
+    providers.push(provider);
+
+    await waitForConnection(provider);
+    expect(callCount).toBe(1);
+
+    // Use provider.disconnect() which sets shouldConnect=false,
+    // then force-terminate to ensure the close event fires promptly.
+    const ws = provider.ws as unknown as {
+      terminate?: () => void;
+      close: () => void;
+    };
+    provider.disconnect();
+    if (ws && typeof ws.terminate === "function") {
+      ws.terminate();
+    }
+
+    // Wait for the disconnect to be processed
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (!provider.wsconnected && provider.ws === null) {
+          resolve();
+        } else {
+          setTimeout(check, 50);
+        }
+      };
+      setTimeout(check, 50);
+    });
+
+    // Wait long enough for a reconnect attempt to have happened if the
+    // shouldConnect guard were broken
+    await new Promise((r) => setTimeout(r, 500));
+
+    // params should NOT have been called again
+    expect(callCount).toBe(1);
+    expect(provider.wsconnected).toBe(false);
+  });
+});
+
 describe("Integration — reconnection", () => {
   it("reconnects and re-syncs after disconnect", async () => {
     const room = `reconnect-${Date.now()}`;


### PR DESCRIPTION
## Summary

Fixes #367

- When `params` is passed as a function to `YProvider`, it was only evaluated on the initial connection. On automatic reconnects (e.g. after a network drop), the params function was not called again, causing dynamic values like auth tokens to go stale.
- Adds `_reconnectWS()` as an overridable method on `WebsocketProvider` that the close handler calls instead of `setupWS` directly. `YProvider` overrides it to re-resolve params before re-establishing the WebSocket.
- If params resolution fails during auto-reconnect, the provider logs a warning and reconnects with stale params rather than killing the retry loop.

## Test plan

- [x] New integration test: sync params function is re-evaluated on automatic reconnect
- [x] New integration test: async params function is re-evaluated on automatic reconnect
- [x] New integration test: `disconnect()` prevents auto-reconnect and params re-evaluation
- [x] All 23 existing unit tests pass
- [x] All 19 integration tests pass (16 existing + 3 new)
- [x] All 14 hibernation/restart tests pass


Made with [Cursor](https://cursor.com)