### PR TITLE
setName() as the sanctioned bootstrap API for non-idFromName DOs

### DIFF
--- a/.changeset/setname-bootstrap.md
+++ b/.changeset/setname-bootstrap.md
@@ -1,0 +1,27 @@
+---
+"partyserver": patch
+---
+
+`setName()` is now the sanctioned bootstrap API for non-`idFromName` DOs.
+
+When `ctx.id.name` is undefined (e.g. Cloudflare Agents facets, which are spawned via `ctx.facets.get(...)` rather than `idFromName()`), `setName(name)` now persists the name to the legacy `__ps_name` storage key in addition to stashing it in memory. This means cold-wake invocations of the DO recover the name through `#ensureInitialized()`'s legacy storage fallback without the framework having to reach into PartyServer's private storage layout.
+
+Frameworks that previously did:
+
+```ts
+await this.ctx.storage.put("__ps_name", name);
+await this.__unsafe_ensureInitialized();
+```
+
+can now do:
+
+```ts
+await this.setName(name);
+```
+
+Backward compatible:
+
+- For DOs addressed via `idFromName()` / `getByName()` (the happy path), `setName()` continues to NOT write storage — `ctx.id.name` is the source of truth and `setName()` is just a no-op-plus-onStart.
+- The pre-existing direct-storage-write pattern keeps working — the storage write becomes idempotent with what `setName()` would do.
+
+`setName()`'s `@deprecated` docblock has been clarified: it remains the supported API for framework-level bootstrap of non-`idFromName` DOs and for delivering initial `props` to `onStart()`. The deprecation only applies to redundant calls on DOs that were addressed via `idFromName()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,14 @@
       "name": "@partyserver/fixture-rpc-sanity",
       "version": "0.0.0"
     },
+    "fixtures/socket-io-chat": {
+      "version": "0.0.0",
+      "extraneous": true
+    },
+    "fixtures/socket-io-private-messaging": {
+      "version": "0.0.0",
+      "extraneous": true
+    },
     "fixtures/tiptap-yjs": {
       "name": "@partyserver/fixture-tiptap-yjs",
       "version": "0.0.15",
@@ -11323,7 +11331,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
         "hono": "^4.12.15",
-        "partyserver": "^0.5.0"
+        "partyserver": "^0.5.1"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
@@ -11462,7 +11470,7 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
-        "partyserver": "^0.5.0",
+        "partyserver": "^0.5.1",
         "partysocket": "^1.1.18"
       },
       "peerDependencies": {
@@ -11481,7 +11489,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
         "partyfn": "^0.1.0",
-        "partyserver": "^0.5.0",
+        "partyserver": "^0.5.1",
         "partysocket": "^1.1.18"
       },
       "peerDependencies": {
@@ -11524,7 +11532,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.5.0",
-        "partyserver": "^0.5.0"
+        "partyserver": "^0.5.1"
       }
     },
     "packages/y-partyserver": {
@@ -11540,7 +11548,7 @@
         "@cloudflare/workers-types": "^4.20260424.1",
         "@types/lodash.debounce": "^4.0.9",
         "@types/node": "25.6.0",
-        "partyserver": "^0.5.0",
+        "partyserver": "^0.5.1",
         "ws": "^8.20.0",
         "yjs": "^13.6.30"
       },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
     "hono": "^4.12.15",
-    "partyserver": "^0.5.0"
+    "partyserver": "^0.5.1"
   }
 }

--- a/packages/partyserver/CHANGELOG.md
+++ b/packages/partyserver/CHANGELOG.md
@@ -9,7 +9,6 @@
   0.5.0 moved the legacy storage hydrate into `alarm()` only, breaking Cloudflare Agents facets and any other framework that writes `__ps_name` directly before calling `__unsafe_ensureInitialized()`. Facet DOs are spawned via `ctx.facets.get(...)` rather than `idFromName()` and therefore have `ctx.id.name === undefined`; they relied on PartyServer reading the storage record back to populate `this.name` before `onStart()`.
 
   Changes:
-
   - Move the legacy `__ps_name` hydrate from `alarm()` into `#ensureInitialized()`, still gated on `!ctx.id.name && !#_name` so it costs nothing on the happy path (normal `idFromName()`/`getByName()` DOs skip the storage read entirely).
   - `Server.fetch()` now delegates to `#ensureInitialized()` for the hydrate instead of doing its own. The `x-partykit-room` header fallback remains as a last resort when neither `ctx.id.name` nor a legacy storage record is available.
   - `Server.alarm()` is simplified — it no longer needs its own hydrate call since `#ensureInitialized()` handles it.
@@ -24,7 +23,6 @@
   Durable Objects now expose `ctx.id.name` on every entry point (constructor, fetch, alarm, hibernating websocket handlers) when the DO is addressed via `idFromName()`/`getByName()`. PartyServer now uses this as the primary source of `this.name`, which simplifies routing, eliminates storage writes, and makes `this.name` available inside the constructor.
 
   Changes in `partyserver`:
-
   - `this.name` resolves from `this.ctx.id.name`. The apologetic `workerd#2240` error message is gone.
   - `this.name` is now available **inside the constructor** and from class field initializers, not just after `setName()`/`fetch()` has run.
   - `routePartykitRequest` no longer issues a `setName()`/`_initAndFetch()` RPC before `fetch()`. The WebSocket path goes from 2 RPCs to 1; the HTTP path remains 1 RPC. Props, when supplied, are delivered to the DO via the `x-partykit-props` request header, set after `onBeforeConnect`/`onBeforeRequest` hooks run.
@@ -36,7 +34,6 @@
   - When reading `this.name` throws, it is because `ctx.id.name` is undefined and no legacy fallback has populated the name: the DO was addressed via `idFromString()` or `newUniqueId()` (both unsupported), the runtime is too old to expose `ctx.id.name`, or a pre-2026-03-15 alarm fired before the legacy storage fallback ran.
 
   Changes in all affected packages (`partyserver`, `partysub`, `partysync`, `y-partyserver`, `hono-party`):
-
   - `@cloudflare/workers-types` peer dependency bumped from `^4.20240729.0` to `^4.20260424.1`. The old range predates `ctx.id.name` in the type surface.
 
   Not supported: addressing PartyServer DOs via `idFromString()` or `newUniqueId()`. These paths return `ctx.id.name === undefined` inside the DO and will surface as a clear error from `this.name`. PartyServer has always assumed name-based addressing via `getServerByName` / `routePartykitRequest`; this release makes that assumption explicit.
@@ -357,14 +354,12 @@
 ### Patch Changes
 
 - [`528adea`](https://github.com/threepointone/partyserver/commit/528adeaced6dce6e888d2f54cc75c3569bf2c277) Thanks [@threepointone](https://github.com/threepointone)! - some fixes and tweaks
-
   - getServerByName was throwing on all requests
   - `Env` is now an optional arg when defining `Server`
   - `y-partyserver/provider` can now take an optional `prefix` arg to use a custom url to connect
   - `routePartyKitRequest`/`getServerByName` now accepts `jurisdiction`
 
   bonus:
-
   - added a bunch of fixtures
   - added stubs for docs
 

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -712,13 +712,18 @@ export class Server<
     }
     if (!this.#_name && ctxName === undefined) {
       // Bootstrap path (DO was addressed without idFromName, e.g.
-      // Cloudflare Agents facets). Stash the name in memory AND
-      // persist to storage so that subsequent cold-wake invocations
+      // Cloudflare Agents facets). Persist to storage AND stash the
+      // name in memory so that subsequent cold-wake invocations
       // (fetch, alarm, websocket handlers, RPC via
       // `__unsafe_ensureInitialized`) can recover the name through
       // `#ensureInitialized()`'s legacy fallback.
-      this.#_name = name;
+      //
+      // Order matters: write storage first so that if it throws,
+      // `#_name` stays undefined and a retry will re-attempt the
+      // storage write (instead of silently no-op'ing because the
+      // in-memory name was already set).
       await this.ctx.storage.put(NAME_STORAGE_KEY, name);
+      this.#_name = name;
     }
     await this.#ensureInitialized();
   }

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -670,19 +670,27 @@ export class Server<
   }
 
   /**
-   * @deprecated for callers that address DOs via `idFromName()` /
-   * `getByName()` — `this.name` is available automatically from
-   * `ctx.id.name` and calling `setName()` is redundant.
+   * Establish this server's name and trigger `onStart()`.
    *
-   * Still appropriate for two use cases:
-   *   1. Delivering initial `props` to `onStart()` (via the optional
-   *      second argument).
-   *   2. Framework-level bootstrap of non-`idFromName` DOs where
+   * Two distinct use cases:
+   *
+   *   1. **Framework-level bootstrap of non-`idFromName` DOs** where
    *      `ctx.id.name` is undefined — for example, Cloudflare Agents
-   *      facets. Calling `setName(name)` from inside such a DO stashes
-   *      the name in memory for the current instance; for
-   *      survival-across-eviction, write `__ps_name` to storage as
-   *      well.
+   *      facets (spawned via `ctx.facets.get(...)`). `setName()` is the
+   *      sanctioned bootstrap primitive: it stashes the name in memory
+   *      AND persists it to storage (under `__ps_name`) so the name
+   *      survives DO eviction and is recovered on cold wake by
+   *      `#ensureInitialized()`.
+   *   2. **Delivering initial `props` to `onStart()`** via the optional
+   *      second argument.
+   *
+   * For DOs addressed via `idFromName()` / `getByName()`, calling
+   * `setName()` is redundant — `this.name` is available automatically
+   * from `ctx.id.name`. Throws if `name` does not match `ctx.id.name`.
+   *
+   * @deprecated for callers that address DOs via `idFromName()` /
+   * `getByName()`. Still the supported API for framework-level
+   * bootstrap and props delivery.
    */
   async setName(name: string, props?: Props) {
     if (!name) {
@@ -703,10 +711,14 @@ export class Server<
       this.#_props = props;
     }
     if (!this.#_name && ctxName === undefined) {
-      // Legacy path only (DO was addressed without idFromName). Stash the
-      // name in memory so subsequent handlers can read `this.name`.
-      // No storage write: PartyServer no longer persists the name itself.
+      // Bootstrap path (DO was addressed without idFromName, e.g.
+      // Cloudflare Agents facets). Stash the name in memory AND
+      // persist to storage so that subsequent cold-wake invocations
+      // (fetch, alarm, websocket handlers, RPC via
+      // `__unsafe_ensureInitialized`) can recover the name through
+      // `#ensureInitialized()`'s legacy fallback.
       this.#_name = name;
+      await this.ctx.storage.put(NAME_STORAGE_KEY, name);
     }
     await this.#ensureInitialized();
   }

--- a/packages/partyserver/src/tests/index.test.ts
+++ b/packages/partyserver/src/tests/index.test.ts
@@ -722,6 +722,49 @@ describe("x-partykit-room header applied before onStart", () => {
   });
 });
 
+describe("setName() as bootstrap API for non-idFromName DOs", () => {
+  it("persists __ps_name to storage so the name survives eviction", async () => {
+    const id = env.SetNameBootstrapServer.newUniqueId();
+    const stub = env.SetNameBootstrapServer.get(id);
+
+    const result = await stub.bootstrap("setname-bootstrap-test");
+    expect(result.onStartName).toBe("setname-bootstrap-test");
+
+    // Verify setName() persisted to storage. Frameworks no longer need
+    // to write __ps_name themselves — `setName()` covers it.
+    const stored = await stub.readStoredName();
+    expect(stored).toBe("setname-bootstrap-test");
+  });
+
+  it("recovers the name on cold-wake fetch via the storage fallback", async () => {
+    const id = env.SetNameBootstrapServer.newUniqueId();
+    const stub = env.SetNameBootstrapServer.get(id);
+    await stub.bootstrap("setname-coldwake-test");
+
+    // Subsequent fetch with no header — must hydrate from storage.
+    const res = await stub.fetch(new Request("http://example.com/"));
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { name: string };
+    expect(data.name).toBe("setname-coldwake-test");
+  });
+
+  it("does NOT write storage when the DO was addressed via idFromName", async () => {
+    // For normal idFromName DOs, ctx.id.name carries the name and
+    // setName() is redundant. It must not write `__ps_name` to
+    // storage in this path — that would re-introduce the per-setName
+    // storage write that 0.5.0 eliminated.
+    const id = env.SetNameBootstrapServer.idFromName("setname-no-write");
+    const stub = env.SetNameBootstrapServer.get(id);
+
+    // Calling setName with the matching name is a no-op on storage;
+    // it just runs onStart.
+    await stub.setName("setname-no-write");
+
+    const stored = await stub.readStoredName();
+    expect(stored).toBeUndefined();
+  });
+});
+
 describe("Framework bootstrap fallback (Agents facets etc.)", () => {
   it("hydrates this.name from __ps_name storage when ctx.id.name is undefined", async () => {
     // Regression guard for Cloudflare Agents facets. Facets are spawned

--- a/packages/partyserver/src/tests/worker.ts
+++ b/packages/partyserver/src/tests/worker.ts
@@ -16,6 +16,7 @@ export type Env = {
   AlarmNameServer: DurableObjectNamespace<AlarmNameServer>;
   NoNameServer: DurableObjectNamespace<NoNameServer>;
   HeaderOnlyOnStartServer: DurableObjectNamespace<HeaderOnlyOnStartServer>;
+  SetNameBootstrapServer: DurableObjectNamespace<SetNameBootstrapServer>;
   FacetLikeBootstrapServer: DurableObjectNamespace<FacetLikeBootstrapServer>;
   NameInConstructorServer: DurableObjectNamespace<NameInConstructorServer>;
   Mixed: DurableObjectNamespace<Mixed>;
@@ -271,6 +272,47 @@ export class HeaderOnlyOnStartServer extends Server {
   async onStart() {
     // Throws if `this.name` isn't resolvable here.
     this.onStartName = this.name;
+  }
+
+  onRequest(): Response {
+    return Response.json({
+      name: this.name,
+      onStartName: this.onStartName
+    });
+  }
+}
+
+/**
+ * Same scenario as `FacetLikeBootstrapServer`, but uses the sanctioned
+ * `setName()` bootstrap API instead of writing `__ps_name` directly to
+ * storage. Verifies that `setName()` alone is sufficient: it stashes
+ * `#_name` in memory AND persists it to storage so cold-wake fetches
+ * recover the name through `#ensureInitialized()`'s legacy fallback.
+ */
+export class SetNameBootstrapServer extends Server {
+  static options = { hibernate: true };
+
+  onStartName: string | null = null;
+
+  async onStart() {
+    try {
+      this.onStartName = this.name;
+    } catch {
+      this.onStartName = null;
+    }
+  }
+
+  async bootstrap(name: string): Promise<{ onStartName: string | null }> {
+    await this.setName(name);
+    return { onStartName: this.onStartName };
+  }
+
+  /**
+   * Probe storage from outside the DO to verify `setName()` persisted
+   * the name under the legacy `__ps_name` key.
+   */
+  async readStoredName(): Promise<string | undefined> {
+    return this.ctx.storage.get<string>("__ps_name");
   }
 
   onRequest(): Response {

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -92,6 +92,10 @@
         "class_name": "HeaderOnlyOnStartServer"
       },
       {
+        "name": "SetNameBootstrapServer",
+        "class_name": "SetNameBootstrapServer"
+      },
+      {
         "name": "FacetLikeBootstrapServer",
         "class_name": "FacetLikeBootstrapServer"
       },
@@ -125,6 +129,7 @@
         "UriServerInMemory",
         "PropsServer",
         "HeaderOnlyOnStartServer",
+        "SetNameBootstrapServer",
         "FacetLikeBootstrapServer",
         "NameInConstructorServer"
       ]

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
-    "partyserver": "^0.5.0",
+    "partyserver": "^0.5.1",
     "partysocket": "^1.1.18"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
     "partyfn": "^0.1.0",
-    "partyserver": "^0.5.0",
+    "partyserver": "^0.5.1",
     "partysocket": "^1.1.18"
   },
   "peerDependencies": {

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.5.0",
-    "partyserver": "^0.5.0"
+    "partyserver": "^0.5.1"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -65,7 +65,7 @@
     "@cloudflare/workers-types": "^4.20260424.1",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "25.6.0",
-    "partyserver": "^0.5.0",
+    "partyserver": "^0.5.1",
     "ws": "^8.20.0",
     "yjs": "^13.6.30"
   },


### PR DESCRIPTION
## Summary

Follow-up to #381 (the 0.5.1 facet hydrate fix). Where #381 made the *runtime* path tolerate frameworks bootstrapping via direct `__ps_name` storage writes, this PR makes the *API* path clean: `setName()` itself now persists the name, so frameworks no longer need to reach into PartyServer's private storage layout.

When `ctx.id.name` is undefined (e.g. Cloudflare Agents facets, spawned via `ctx.facets.get(...)` rather than `idFromName()`), `setName(name)` now:
1. Stashes the name in `#_name` (existing behavior)
2. **Persists it to `__ps_name` storage** (new), so cold-wake invocations recover the name through `#ensureInitialized()`'s legacy storage fallback

When `ctx.id.name` is defined (the happy path for `idFromName`/`getByName` DOs), `setName()` continues to NOT write storage — `ctx.id.name` is the source of truth.

## Migration for framework authors

Cloudflare Agents currently does (in `_cf_initAsFacet`):

```ts
await Promise.all([
  this.ctx.storage.put("cf_agents_is_facet", true),
  this.ctx.storage.put("__ps_name", name),
  this.ctx.storage.put("cf_agents_parent_path", parentPath)
]);
await this.__unsafe_ensureInitialized();
```

Once Agents bumps to this release, they can simplify to:

```ts
await Promise.all([
  this.ctx.storage.put("cf_agents_is_facet", true),
  this.ctx.storage.put("cf_agents_parent_path", parentPath)
]);
await this.setName(name);   // writes __ps_name + sets #_name + runs onStart
```

Migration is optional. The existing direct-storage-write pattern keeps working — the storage write just becomes idempotent with what `setName()` would do.

## Test plan

- [x] New `SetNameBootstrapServer` + 3 tests:
    - `setName()` on a `newUniqueId()` DO persists `__ps_name` to storage (verified by reading storage back)
    - Cold-wake fetch recovers the name via the storage fallback
    - `setName()` does NOT write storage when `ctx.id.name` is set (regression guard for the 0.5.0 zero-storage-write win)
- [x] All 57 partyserver tests pass
- [x] Full repo test suite passes (partyserver, partysub, partywhen, partytracks, y-partyserver — 402 tests total)
- [x] Types, lint, format clean
- [ ] Follow-up: open an issue / PR in cloudflare/agents tracking the optional `setName()` migration

## Long-term context

Workerd-team work (Option F in the discussion thread) will eventually expose `ctx.id.name` for facets natively, at which point `setName()` becomes redundant for facets too. Until then, `setName()` is the supported bootstrap primitive.


Made with [Cursor](https://cursor.com)