### PR TITLE
Security: Command injection risk via `execSync` with interpolated path

### DIFF
--- a/scripts/typecheck.ts
+++ b/scripts/typecheck.ts
@@ -1,4 +1,4 @@
-import { type ExecException, execSync } from "node:child_process";
+import { type ExecException, execFileSync } from "node:child_process";
 import fg from "fast-glob";
 
 const tsconfigs: string[] = [];
@@ -21,9 +21,10 @@ const results: Result[] = [];
 for (const tsconfig of tsconfigs) {
   console.log(`Checking ${tsconfig}...`);
   try {
-    const output = execSync(`tsc -p ${tsconfig}`, {
+    const output = execFileSync("tsc", ["-p", tsconfig], {
       encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: false
     });
     results.push({ tsconfig, success: true, output });
     console.log(`✅ ${tsconfig} - OK`);


### PR DESCRIPTION
## Summary

Security: Command injection risk via `execSync` with interpolated path

## Problem

**Severity**: `High` | **File**: `scripts/typecheck.ts:L26`

The script builds a shell command using string interpolation (`tsc -p ${tsconfig}`) where `tsconfig` comes from filesystem glob results. If a malicious path containing shell metacharacters is introduced (e.g., in a compromised checkout/CI context), this can execute unintended commands.

## Solution

Use `execFileSync`/`spawnSync` with argument arrays and `shell: false` (e.g., `execFileSync('tsc', ['-p', tsconfig], ...)`) to avoid shell interpretation.

## Changes

- `scripts/typecheck.ts` (modified)