### PR TITLE
Document facet bootstrap pattern, no runtime change

### DIFF
--- a/.changeset/facet-name-resolution.md
+++ b/.changeset/facet-name-resolution.md
@@ -1,0 +1,17 @@
+---
+"partyserver": patch
+---
+
+Document and test the supported pattern for using PartyServer with [Durable Object Facets](https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/). No runtime behavior change.
+
+**Background.** Facets spawned via `ctx.facets.get(name, factory)` _without_ an explicit `id` in `FacetStartupOptions` inherit the parent DO's `ctx.id` — including `ctx.id.name`. PartyServer's `name` getter reads `ctx.id.name` straight through, so on an implicit-id facet `this.name` returns the _parent's_ name rather than the facet's logical name. This is a faithful reflection of the workerd contract, but it's almost never what framework authors expect.
+
+The fix is at the call site, not in PartyServer: pass `id: someBoundDONamespace.idFromName(facetName)` to `ctx.facets.get(...)`. The facet then gets its own native `ctx.id.name === facetName` and PartyServer's `name` getter does the right thing automatically. No `setName()` is required, no `__ps_name` storage record is written, and cold-wake recovery happens for free because the factory re-runs and `idFromName` is deterministic.
+
+This release adds:
+
+- **A "Using PartyServer with Durable Object Facets" section in the README** that walks through the recommended pattern with a code example, calls out the implicit-id footgun explicitly, and documents that plain-string `id` values are not a substitute for `idFromName(facetName)` (workerd treats string ids as `idFromString`-like, so the resulting facet has no `ctx.id.name`).
+- **`setName()` docstring updated** to clarify that facets are NOT a `setName()` use case — point to the explicit-`id` pattern instead. The original `setName()` `ctx.id.name` mismatch throw is preserved as a typo guard for the `idFromName` happy path.
+- **End-to-end facet test coverage** against the real workerd `ctx.facets.get(...)` API. A `FacetParent` / `FacetChild` fixture exercises both the implicit-id path (pinning the runtime contract that `this.name` returns the parent's name in that flow — i.e., behavior-as-documentation so framework authors are unsurprised) and the explicit-id path (recommended; verifies that all reasonable id-construction strategies work and that cold wake recovers without any storage record). Plain-string `id` is also tested; the test asserts it does NOT carry a name, pinning the contract so callers don't get tempted by the type signature.
+
+The runtime behavior of `Server` (the `name` getter, `setName()`, the legacy `__ps_name` hydrate inside `#ensureInitialized()`) is unchanged from 0.5.2.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11331,7 +11331,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
         "hono": "^4.12.15",
-        "partyserver": "^0.5.1"
+        "partyserver": "^0.5.2"
       },
       "peerDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
@@ -11470,7 +11470,7 @@
       "license": "ISC",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
-        "partyserver": "^0.5.1",
+        "partyserver": "^0.5.2",
         "partysocket": "^1.1.18"
       },
       "peerDependencies": {
@@ -11489,7 +11489,7 @@
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260424.1",
         "partyfn": "^0.1.0",
-        "partyserver": "^0.5.1",
+        "partyserver": "^0.5.2",
         "partysocket": "^1.1.18"
       },
       "peerDependencies": {
@@ -11532,7 +11532,7 @@
       "license": "ISC",
       "dependencies": {
         "cron-parser": "^5.5.0",
-        "partyserver": "^0.5.1"
+        "partyserver": "^0.5.2"
       }
     },
     "packages/y-partyserver": {
@@ -11548,7 +11548,7 @@
         "@cloudflare/workers-types": "^4.20260424.1",
         "@types/lodash.debounce": "^4.0.9",
         "@types/node": "25.6.0",
-        "partyserver": "^0.5.1",
+        "partyserver": "^0.5.2",
         "ws": "^8.20.0",
         "yjs": "^13.6.30"
       },

--- a/packages/hono-party/package.json
+++ b/packages/hono-party/package.json
@@ -37,6 +37,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
     "hono": "^4.12.15",
-    "partyserver": "^0.5.1"
+    "partyserver": "^0.5.2"
   }
 }

--- a/packages/partyserver/CHANGELOG.md
+++ b/packages/partyserver/CHANGELOG.md
@@ -22,7 +22,6 @@
   ```
 
   Backward compatible:
-
   - For DOs addressed via `idFromName()` / `getByName()` (the happy path), `setName()` continues to NOT write storage — `ctx.id.name` is the source of truth and `setName()` is just a no-op-plus-onStart.
   - The pre-existing direct-storage-write pattern keeps working — the storage write becomes idempotent with what `setName()` would do.
 
@@ -37,7 +36,6 @@
   0.5.0 moved the legacy storage hydrate into `alarm()` only, breaking Cloudflare Agents facets and any other framework that writes `__ps_name` directly before calling `__unsafe_ensureInitialized()`. Facet DOs are spawned via `ctx.facets.get(...)` rather than `idFromName()` and therefore have `ctx.id.name === undefined`; they relied on PartyServer reading the storage record back to populate `this.name` before `onStart()`.
 
   Changes:
-
   - Move the legacy `__ps_name` hydrate from `alarm()` into `#ensureInitialized()`, still gated on `!ctx.id.name && !#_name` so it costs nothing on the happy path (normal `idFromName()`/`getByName()` DOs skip the storage read entirely).
   - `Server.fetch()` now delegates to `#ensureInitialized()` for the hydrate instead of doing its own. The `x-partykit-room` header fallback remains as a last resort when neither `ctx.id.name` nor a legacy storage record is available.
   - `Server.alarm()` is simplified — it no longer needs its own hydrate call since `#ensureInitialized()` handles it.
@@ -52,7 +50,6 @@
   Durable Objects now expose `ctx.id.name` on every entry point (constructor, fetch, alarm, hibernating websocket handlers) when the DO is addressed via `idFromName()`/`getByName()`. PartyServer now uses this as the primary source of `this.name`, which simplifies routing, eliminates storage writes, and makes `this.name` available inside the constructor.
 
   Changes in `partyserver`:
-
   - `this.name` resolves from `this.ctx.id.name`. The apologetic `workerd#2240` error message is gone.
   - `this.name` is now available **inside the constructor** and from class field initializers, not just after `setName()`/`fetch()` has run.
   - `routePartykitRequest` no longer issues a `setName()`/`_initAndFetch()` RPC before `fetch()`. The WebSocket path goes from 2 RPCs to 1; the HTTP path remains 1 RPC. Props, when supplied, are delivered to the DO via the `x-partykit-props` request header, set after `onBeforeConnect`/`onBeforeRequest` hooks run.
@@ -64,7 +61,6 @@
   - When reading `this.name` throws, it is because `ctx.id.name` is undefined and no legacy fallback has populated the name: the DO was addressed via `idFromString()` or `newUniqueId()` (both unsupported), the runtime is too old to expose `ctx.id.name`, or a pre-2026-03-15 alarm fired before the legacy storage fallback ran.
 
   Changes in all affected packages (`partyserver`, `partysub`, `partysync`, `y-partyserver`, `hono-party`):
-
   - `@cloudflare/workers-types` peer dependency bumped from `^4.20240729.0` to `^4.20260424.1`. The old range predates `ctx.id.name` in the type surface.
 
   Not supported: addressing PartyServer DOs via `idFromString()` or `newUniqueId()`. These paths return `ctx.id.name === undefined` inside the DO and will surface as a clear error from `this.name`. PartyServer has always assumed name-based addressing via `getServerByName` / `routePartykitRequest`; this release makes that assumption explicit.
@@ -385,14 +381,12 @@
 ### Patch Changes
 
 - [`528adea`](https://github.com/threepointone/partyserver/commit/528adeaced6dce6e888d2f54cc75c3569bf2c277) Thanks [@threepointone](https://github.com/threepointone)! - some fixes and tweaks
-
   - getServerByName was throwing on all requests
   - `Env` is now an optional arg when defining `Server`
   - `y-partyserver/provider` can now take an optional `prefix` arg to use a custom url to connect
   - `routePartyKitRequest`/`getServerByName` now accepts `jurisdiction`
 
   bonus:
-
   - added a bunch of fixtures
   - added stubs for docs
 

--- a/packages/partyserver/README.md
+++ b/packages/partyserver/README.md
@@ -129,7 +129,9 @@ These methods can be optionally `async`:
 
 ## Properties
 
-- `.name` - (readonly) the server's name, as provided to `getServerByName()` or `routePartykitRequest()`. Resolves from the underlying Durable Object's `ctx.id.name`, so it is available inside every entry point — including the constructor, `onStart()`, `onAlarm()`, and hibernating websocket handlers. This assumes the DO was addressed via `idFromName()`/`getByName()` (which is the only supported way to address PartyServer DOs).
+- `.name` - (readonly) the server's name. Resolves from the underlying Durable Object's `ctx.id.name`, populated whenever the DO is addressed via `idFromName()` / `getByName()` — which is the supported way to address PartyServer DOs. Available inside every entry point including the constructor, `onStart()`, `onAlarm()`, and hibernating websocket handlers. (For the narrow case of legacy DOs bootstrapped via `setName()` — e.g. a `__ps_name` storage record from an older version — that override is recovered automatically. PartyServer no longer writes that record itself for new DOs.)
+
+  DOs addressed via `idFromString()` or `newUniqueId()` without a `setName()` bootstrap are not supported and `.name` will throw.
 
 - `.ctx` - the context object for the Durable Object, containing references to [`storage`](https://developers.cloudflare.com/durable-objects/api/transactional-storage-api/)
 
@@ -175,6 +177,47 @@ export class MyServer extends Server {
     - If it returns a `Response`, it will be returned instead of the original request. Use this to return a custom response, such as a 404 or 403.
     - If it returns `undefined` or `null`, the request will be passed to the server as normal.
   - `onBeforeRequest` - A function that can modify the request before it's passed to the server. This is exactly the same as `onBeforeConnect`, but for HTTP requests.
+
+### Using PartyServer with Durable Object Facets
+
+[Durable Object Facets](https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/) let you spawn a child DO from inside a parent's isolate via `ctx.facets.get(name, factory)`. This is useful for frameworks (e.g. Cloudflare Agents sub-agents) that want isolated SQLite storage per facet without exposing a separate Durable Object namespace.
+
+Facets that extend `Server` work, but **you must pass an explicit `id` in `FacetStartupOptions`**. Otherwise the facet inherits the parent DO's `ctx.id` (including `ctx.id.name`), and `this.name` on the facet will return the _parent's_ name — almost never what you want.
+
+```ts
+import { Server } from "partyserver";
+
+export class FacetChild extends Server {
+  // `this.name` here will report `facetName` (NOT the parent's name)
+  // because we passed an explicit `id` at spawn time below.
+  onStart() {
+    console.log("facet started:", this.name);
+  }
+}
+
+export class ParentServer extends Server {
+  async fetch(request: Request) {
+    const facetName = "child-foo";
+
+    // Recommended: construct the id via `ctx.exports[BoundDOClass]`,
+    // which is also a `DurableObjectNamespace`. Any bound DO class
+    // works — the id is opaque + a name; nothing routes through the
+    // namespace at runtime for facets.
+    const id = this.ctx.exports.ParentServer.idFromName(facetName);
+
+    const facet = this.ctx.facets.get(facetName, () => ({
+      class: this.ctx.exports.FacetChild,
+      id // <-- the critical bit
+    }));
+
+    return facet.fetch(request);
+  }
+}
+```
+
+Without the explicit `id`, the facet's `ctx.id.name` is the parent's name, `this.name` returns the parent's name, and `setName(facetName)` throws (it would mismatch `ctx.id.name`). With the explicit `id`, the facet has its own native `ctx.id.name`, no `setName()` is needed, no storage write is involved, and cold wakes recover the name automatically (the factory re-runs and `idFromName(facetName)` is deterministic).
+
+Plain strings (`id: "child-foo"`) are NOT a substitute for `idFromName(facetName)` — workerd treats a string `id` as `idFromString`-like and the resulting facet has no `ctx.id.name`, so `this.name` will throw.
 
 ## Comparison to Erlang/Elixir
 

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -551,15 +551,19 @@ export class Server<
    *   1. Pre-2026-03-15 alarms, which fire without `ctx.id.name`
    *      populated on the alarm handler (see the Durable Objects
    *      ID docs: https://developers.cloudflare.com/durable-objects/api/id/#name).
-   *   2. Framework-level bootstrap patterns that write `__ps_name`
-   *      directly before calling `__unsafe_ensureInitialized()` —
-   *      notably Cloudflare Agents facets, which are addressed via
-   *      `ctx.facets.get()` rather than `idFromName()` and therefore
-   *      do not receive a `ctx.id.name`.
+   *   2. Legacy framework-level bootstrap patterns that write
+   *      `__ps_name` directly (or call `setName()`) before triggering
+   *      `__unsafe_ensureInitialized()` — typically DOs addressed via
+   *      `idFromString()` / `newUniqueId()` plus a name override.
    *
    * PartyServer no longer writes this record itself. Everything that
    * reads it is reading something written by an older version of
    * PartyServer or by a framework that embeds it.
+   *
+   * Not relevant to Cloudflare Agents facets — the recommended
+   * facet pattern passes an explicit `id` in `FacetStartupOptions`,
+   * so the facet has its own `ctx.id.name` and never hits this
+   * fallback. See the README for the full pattern.
    */
   async #hydrateNameFromLegacyStorage(): Promise<void> {
     if (this.#_name) return;
@@ -672,25 +676,43 @@ export class Server<
   /**
    * Establish this server's name and trigger `onStart()`.
    *
-   * Two distinct use cases:
+   * Use cases:
    *
-   *   1. **Framework-level bootstrap of non-`idFromName` DOs** where
-   *      `ctx.id.name` is undefined — for example, Cloudflare Agents
-   *      facets (spawned via `ctx.facets.get(...)`). `setName()` is the
-   *      sanctioned bootstrap primitive: it stashes the name in memory
-   *      AND persists it to storage (under `__ps_name`) so the name
-   *      survives DO eviction and is recovered on cold wake by
-   *      `#ensureInitialized()`.
-   *   2. **Delivering initial `props` to `onStart()`** via the optional
-   *      second argument.
+   *   1. **Framework-level bootstrap of DOs where `ctx.id.name` is
+   *      undefined** — e.g. DOs addressed via `idFromString()` /
+   *      `newUniqueId()`. `setName()` stashes the name in memory and
+   *      persists it under `__ps_name` so cold-wake invocations
+   *      recover it via `#ensureInitialized()`'s legacy fallback.
+   *   2. **Delivering initial `props` to `onStart()`** via the
+   *      optional second argument.
    *
    * For DOs addressed via `idFromName()` / `getByName()`, calling
    * `setName()` is redundant — `this.name` is available automatically
    * from `ctx.id.name`. Throws if `name` does not match `ctx.id.name`.
    *
+   * **Not appropriate for facets.** Cloudflare Agents and any other
+   * framework using `ctx.facets.get(...)` should pass an explicit
+   * `id` in `FacetStartupOptions` so the facet has its own
+   * `ctx.id.name`:
+   *
+   * ```ts
+   * const stub = ctx.facets.get(facetKey, () => ({
+   *   class: ChildClass,
+   *   id: ctx.exports.SomeBoundDOClass.idFromName(facetName),
+   * }));
+   * ```
+   *
+   * Without an explicit `id`, the facet inherits the parent DO's
+   * `ctx.id` (including `ctx.id.name`), and `setName()` will throw
+   * the ctx.id.name-mismatch error because the facet's intended
+   * name differs from the parent's. See
+   * https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/
+   * for the `FacetStartupOptions.id` semantics.
+   *
    * @deprecated for callers that address DOs via `idFromName()` /
    * `getByName()`. Still the supported API for framework-level
-   * bootstrap and props delivery.
+   * bootstrap of header/`newUniqueId`-addressed DOs and for
+   * delivering initial `props` to `onStart()`.
    */
   async setName(name: string, props?: Props) {
     if (!name) {

--- a/packages/partyserver/src/tests/index.test.ts
+++ b/packages/partyserver/src/tests/index.test.ts
@@ -626,6 +626,12 @@ describe("Name resolution", () => {
   });
 
   it("setName throws when called with a name different from ctx.id.name", async () => {
+    // Sanity guard: setName() on an idFromName-addressed DO must
+    // match `ctx.id.name`. Mismatches almost always indicate a typo
+    // and should fail loudly rather than silently override. (Facets
+    // are not a counter-example — facets should be created with an
+    // explicit `id` in `FacetStartupOptions`, giving them their own
+    // `ctx.id.name` so `setName()` isn't needed at all.)
     const id = env.AlarmNameServer.idFromName("ctx-id-mismatch");
     const stub = env.AlarmNameServer.get(id);
 
@@ -641,6 +647,139 @@ describe("Name resolution", () => {
     const data = (await res.json()) as { threw: boolean; message?: string };
     expect(data.threw).toBe(true);
     expect(data.message).toMatch(/created for name "ctx-id-mismatch"/);
+  });
+
+  describe("facets (real ctx.facets.get round-trip)", () => {
+    // End-to-end coverage of the workerd facet API and partyserver's
+    // contract on top of it. These tests exist as executable docs —
+    // the supported pattern is to pass `id` in FacetStartupOptions
+    // so the facet has its own `ctx.id.name`. The implicit-id flow
+    // is also exercised here to pin down the runtime contract: a
+    // facet without explicit `id` inherits the parent's `ctx.id`,
+    // including `ctx.id.name`. Frameworks that want their facets
+    // to have logical names different from the parent's MUST pass
+    // an explicit `id`.
+
+    it("facet WITHOUT explicit id inherits the parent DO's ctx.id.name (workerd contract)", async () => {
+      // Documents the runtime behavior — not a recommendation. If
+      // you call `ctx.facets.get(name, () => ({ class }))` without
+      // an `id`, the facet's `ctx.id` IS the parent's id. PartyServer
+      // reflects that faithfully: `this.name` on the facet returns
+      // the parent's name, NOT the facet's `name` argument. This is
+      // almost always not what you want — see the explicit-id test
+      // below for the recommended pattern.
+      const parentName = "facet-parent-" + Math.random().toString(36).slice(2);
+      const facetName = "facet-child-" + Math.random().toString(36).slice(2);
+
+      const id = env.FacetParent.idFromName(parentName);
+      const stub = env.FacetParent.get(id);
+
+      const result = await stub.spawnImplicitId(facetName);
+
+      expect(result.parentName).toBe(parentName);
+      // The facet's ctx.id.name is the PARENT's name, because facets
+      // without explicit id share the parent's underlying DO id.
+      expect(result.facet.ctxIdName).toBe(parentName);
+      // Therefore this.name on the facet also returns the parent's
+      // name. Consumers reading this.name from inside an implicit-id
+      // facet will see the wrong value.
+      expect(result.facet.name).toBe(parentName);
+      // No storage record is involved — the implicit-id path doesn't
+      // touch __ps_name.
+      expect(result.facet.storedName).toBeUndefined();
+    });
+
+    it("facet WITH explicit id survives cold wake without any storage hydrate (ctx.id.name is the source of truth)", async () => {
+      // Variant of the explicit-id path that exercises cold wake.
+      // The factory passed to ctx.facets.get() runs again on resume,
+      // and idFromName(facetName) is deterministic, so the resumed
+      // facet gets the same ctx.id.name. No storage record needed.
+      const parentName = "facet-parent-" + Math.random().toString(36).slice(2);
+      const facetName = "facet-child-" + Math.random().toString(36).slice(2);
+
+      const id = env.FacetParent.idFromName(parentName);
+      const stub = env.FacetParent.get(id);
+
+      await stub.spawnWithExplicitId(facetName, "env-namespace");
+      // No __ps_name was written, so the only thing that can carry
+      // the name across eviction is the deterministic id factory.
+      // This implicitly tests that it works.
+      const result = await stub.spawnWithExplicitId(facetName, "env-namespace");
+      expect(result.facet.name).toBe(facetName);
+      expect(result.facet.ctxIdName).toBe(facetName);
+      expect(result.facet.storedName).toBeUndefined();
+    });
+
+    it("facet WITH explicit id (FacetStartupOptions.id) gets its own ctx.id.name — no setName needed", async () => {
+      // Per https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/,
+      // FacetStartupOptions.id is optional; when supplied, the facet's
+      // `ctx.id` reflects that id rather than inheriting the parent's.
+      // This is the recommended pattern — the facet gets a real
+      // `ctx.id.name === facetName` and partyserver's `name` getter
+      // returns it without any setName/__ps_name override mechanism.
+      //
+      // The id can be constructed from any DurableObjectNamespace.
+      // Two ergonomic options:
+      //   - env binding (requires knowing the binding name)
+      //   - `ctx.exports[BoundClassName]` (works with any bound DO
+      //     class; no env knowledge required — recommended for
+      //     framework code)
+      // A plain string is NOT a valid id — workerd treats it as
+      // idFromString-like and the resulting facet has no
+      // `ctx.id.name`, so `this.name` throws.
+      const parentName = "facet-parent-" + Math.random().toString(36).slice(2);
+      const facetName = "facet-child-" + Math.random().toString(36).slice(2);
+
+      const id = env.FacetParent.idFromName(parentName);
+      const stub = env.FacetParent.get(id);
+
+      // Each strategy gets a fresh facet name so the factory actually
+      // runs (resuming an existing facet skips the factory and would
+      // mask strategy-specific failures).
+      const fromEnvNs = (
+        await stub.spawnWithExplicitId(
+          `${facetName}-env-namespace`,
+          "env-namespace"
+        )
+      ).facet;
+      const fromCtxExportsNs = (
+        await stub.spawnWithExplicitId(
+          `${facetName}-ctx-exports-namespace`,
+          "ctx-exports-namespace"
+        )
+      ).facet;
+      const fromPlainStr = (
+        await stub.spawnWithExplicitId(
+          `${facetName}-plain-string`,
+          "plain-string"
+        )
+      ).facet;
+
+      // env-namespace: works.
+      expect(fromEnvNs.name).toBe(`${facetName}-env-namespace`);
+      expect(fromEnvNs.ctxIdName).toBe(`${facetName}-env-namespace`);
+      expect(fromEnvNs.storedName).toBeUndefined();
+      expect(fromEnvNs.onStartName).toBe(`${facetName}-env-namespace`);
+
+      // ctx-exports-namespace: also works, no env knowledge needed.
+      // Recommended for framework code.
+      expect(fromCtxExportsNs.name).toBe(`${facetName}-ctx-exports-namespace`);
+      expect(fromCtxExportsNs.ctxIdName).toBe(
+        `${facetName}-ctx-exports-namespace`
+      );
+      expect(fromCtxExportsNs.storedName).toBeUndefined();
+      expect(fromCtxExportsNs.onStartName).toBe(
+        `${facetName}-ctx-exports-namespace`
+      );
+
+      // plain-string: produces a valid facet but ctx.id.name is
+      // undefined and this.name throws. snapshot() catches the
+      // throw and returns name: null. Pinning this contract so
+      // callers don't get tempted by the type signature accepting
+      // `string`.
+      expect(fromPlainStr.name).toBeNull();
+      expect(fromPlainStr.ctxIdName).toBeUndefined();
+    });
   });
 
   it("getServerByName awaits onStart before returning, so user-defined RPCs see initialized state", async () => {

--- a/packages/partyserver/src/tests/worker.ts
+++ b/packages/partyserver/src/tests/worker.ts
@@ -32,6 +32,9 @@ export type Env = {
   UriServer: DurableObjectNamespace<UriServer>;
   UriServerInMemory: DurableObjectNamespace<UriServerInMemory>;
   PropsServer: DurableObjectNamespace<PropsServer>;
+  FacetParent: DurableObjectNamespace<FacetParent>;
+  // FacetChild has no binding — it's reached via ctx.facets.get() from
+  // FacetParent's isolate, just like Cloudflare Agents sub-agents.
 };
 
 export class Stateful extends Server {
@@ -324,12 +327,18 @@ export class SetNameBootstrapServer extends Server {
 }
 
 /**
- * Simulates a framework-level bootstrap pattern (e.g. Cloudflare Agents
- * facets) where the DO is NOT addressed via `idFromName()` — so
- * `ctx.id.name` is undefined — but the framework writes `__ps_name` to
- * storage directly and then triggers `onStart()`. PartyServer must pick
- * up the legacy storage record as a fallback so `onStart()` and
+ * Legacy bootstrap fixture: a DO addressed via `newUniqueId()` (so
+ * `ctx.id.name` is undefined) whose framework writes `__ps_name` to
+ * storage directly and then triggers `onStart()`. PartyServer must
+ * pick up the legacy storage record as a fallback so `onStart()` and
  * subsequent handlers can read `this.name`.
+ *
+ * Note: the class name is historical — it does NOT reflect how
+ * Cloudflare Agents facets actually work. Real facets (spawned via
+ * `ctx.facets.get(...)`) inherit the parent DO's `ctx.id` and should
+ * be created with an explicit `id` in `FacetStartupOptions` so the
+ * facet has its own `ctx.id.name`. See the `facets` describe block
+ * in `index.test.ts` for the recommended facet pattern.
  */
 export class FacetLikeBootstrapServer extends Server {
   static options = { hibernate: true };
@@ -654,6 +663,145 @@ export class CorsServer extends Server {
 export class CustomCorsServer extends Server {
   onRequest(): Response | Promise<Response> {
     return Response.json({ customCors: true });
+  }
+}
+
+/**
+ * Sub-DO spawned as a facet from `FacetParent` via `ctx.facets.get()`.
+ *
+ * The facet exposes a few RPC probes the test uses to inspect its
+ * own identity from inside (since `ctx.id.name` etc. depend on how
+ * `FacetStartupOptions.id` was supplied at the parent's
+ * `ctx.facets.get(...)` call).
+ *
+ * `getName()` calls `__unsafe_ensureInitialized()` first so the test
+ * exercises the realistic cold-wake path (native DO RPCs don't pass
+ * through `Server.fetch`, so `#ensureInitialized()` would otherwise
+ * not run). This mirrors what frameworks like Cloudflare Agents do
+ * inside their RPC bridges.
+ */
+export class FacetChild extends Server {
+  static options = { hibernate: true };
+
+  onStartName: string | null = null;
+
+  async onStart() {
+    try {
+      this.onStartName = this.name;
+    } catch {
+      this.onStartName = null;
+    }
+  }
+
+  async getName(): Promise<string> {
+    await this.__unsafe_ensureInitialized();
+    return this.name;
+  }
+
+  async getCtxIdName(): Promise<string | undefined> {
+    return this.ctx.id.name;
+  }
+
+  async getStoredName(): Promise<string | undefined> {
+    return this.ctx.storage.get<string>("__ps_name");
+  }
+
+  async getOnStartName(): Promise<string | null> {
+    await this.__unsafe_ensureInitialized();
+    return this.onStartName;
+  }
+
+  /**
+   * Convenience: snapshot all four name-related sources in one
+   * round trip. Tries `getName()` first, but tolerates it throwing
+   * (which it will when `ctx.id.name` is undefined and no `setName`
+   * override has run) and reports `null` instead.
+   */
+  async snapshot(): Promise<{
+    name: string | null;
+    ctxIdName: string | undefined;
+    storedName: string | undefined;
+    onStartName: string | null;
+  }> {
+    let name: string | null = null;
+    try {
+      name = await this.getName();
+    } catch {
+      name = null;
+    }
+    return {
+      name,
+      ctxIdName: this.ctx.id.name,
+      storedName: await this.ctx.storage.get<string>("__ps_name"),
+      onStartName: this.onStartName
+    };
+  }
+}
+
+/**
+ * Parent DO that spawns a `FacetChild` via the workerd facet API.
+ */
+export class FacetParent extends Server {
+  /**
+   * Spawn a facet WITHOUT an explicit `id`. Per the Cloudflare facet
+   * docs, this causes the facet to inherit the parent's `ctx.id`
+   * (including `ctx.id.name`). Used by the test to document this
+   * runtime contract — it's not a recommended pattern.
+   */
+  async spawnImplicitId(facetName: string): Promise<{
+    parentName: string;
+    facet: {
+      name: string | null;
+      ctxIdName: string | undefined;
+      storedName: string | undefined;
+      onStartName: string | null;
+    };
+  }> {
+    const Cls = (this.ctx.exports as Record<string, unknown>)
+      .FacetChild as DurableObjectClass<FacetChild>;
+    const stub = this.ctx.facets.get(facetName, () => ({
+      class: Cls
+    })) as unknown as DurableObjectStub<FacetChild>;
+    return { parentName: this.name, facet: await stub.snapshot() };
+  }
+
+  /**
+   * Spawn a facet WITH an explicit `id` constructed three different
+   * ways, so the test can confirm which work. The recommended
+   * pattern for frameworks is the `ctx-exports-namespace` form:
+   * `ctx.exports[BoundClassName].idFromName(facetName)`. It works
+   * without needing to know an env binding name, and produces a
+   * facet whose `ctx.id.name` is the facet's own name.
+   */
+  async spawnWithExplicitId(
+    facetName: string,
+    idSource: "env-namespace" | "ctx-exports-namespace" | "plain-string"
+  ): Promise<{
+    parentName: string;
+    facet: {
+      name: string | null;
+      ctxIdName: string | undefined;
+      storedName: string | undefined;
+      onStartName: string | null;
+    };
+  }> {
+    const Cls = (this.ctx.exports as Record<string, unknown>)
+      .FacetChild as DurableObjectClass<FacetChild>;
+    let id: DurableObjectId | string;
+    if (idSource === "env-namespace") {
+      id = (this.env as Env).FacetParent.idFromName(facetName);
+    } else if (idSource === "ctx-exports-namespace") {
+      const ns = (this.ctx.exports as Record<string, unknown>)
+        .FacetParent as DurableObjectNamespace<FacetParent>;
+      id = ns.idFromName(facetName);
+    } else {
+      id = facetName;
+    }
+    const stub = this.ctx.facets.get(facetName, () => ({
+      class: Cls,
+      id
+    })) as unknown as DurableObjectStub<FacetChild>;
+    return { parentName: this.name, facet: await stub.snapshot() };
   }
 }
 

--- a/packages/partyserver/src/tests/wrangler.jsonc
+++ b/packages/partyserver/src/tests/wrangler.jsonc
@@ -102,6 +102,10 @@
       {
         "name": "NameInConstructorServer",
         "class_name": "NameInConstructorServer"
+      },
+      {
+        "name": "FacetParent",
+        "class_name": "FacetParent"
       }
     ]
   },
@@ -131,7 +135,9 @@
         "HeaderOnlyOnStartServer",
         "SetNameBootstrapServer",
         "FacetLikeBootstrapServer",
-        "NameInConstructorServer"
+        "NameInConstructorServer",
+        "FacetParent",
+        "FacetChild"
       ]
     }
   ]

--- a/packages/partysub/package.json
+++ b/packages/partysub/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
-    "partyserver": "^0.5.1",
+    "partyserver": "^0.5.2",
     "partysocket": "^1.1.18"
   }
 }

--- a/packages/partysync/package.json
+++ b/packages/partysync/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260424.1",
     "partyfn": "^0.1.0",
-    "partyserver": "^0.5.1",
+    "partyserver": "^0.5.2",
     "partysocket": "^1.1.18"
   },
   "peerDependencies": {

--- a/packages/partywhen/package.json
+++ b/packages/partywhen/package.json
@@ -29,6 +29,6 @@
   "description": "A library for scheduling and running tasks in Cloudflare Workers",
   "dependencies": {
     "cron-parser": "^5.5.0",
-    "partyserver": "^0.5.1"
+    "partyserver": "^0.5.2"
   }
 }

--- a/packages/y-partyserver/package.json
+++ b/packages/y-partyserver/package.json
@@ -65,7 +65,7 @@
     "@cloudflare/workers-types": "^4.20260424.1",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "25.6.0",
-    "partyserver": "^0.5.1",
+    "partyserver": "^0.5.2",
     "ws": "^8.20.0",
     "yjs": "^13.6.30"
   },


### PR DESCRIPTION
## Summary

Adds documentation and end-to-end test coverage for using PartyServer with [Durable Object Facets](https://developers.cloudflare.com/dynamic-workers/usage/durable-object-facets/). **No runtime behavior change** — the `Server` class (`name` getter, `setName()`, `#hydrateNameFromLegacyStorage`, `#ensureInitialized`) is byte-identical to 0.5.2.

### What this fixes (and what it doesn't)

Facets spawned via `ctx.facets.get(name, factory)` *without* an explicit `id` in `FacetStartupOptions` inherit the parent DO's `ctx.id` — including `ctx.id.name`. PartyServer's `name` getter reads `ctx.id.name` straight through, so on an implicit-id facet `this.name` returns the *parent's* name rather than the facet's logical name. This is faithful to the workerd contract but it's almost never what framework authors expect.

The fix is at the call site, not in PartyServer: pass `id: someBoundDoNamespace.idFromName(facetName)` (or the equivalent via `ctx.exports[BoundClassName].idFromName(facetName)`) to `ctx.facets.get(...)`. The facet then gets its own native `ctx.id.name === facetName` and PartyServer's `name` getter does the right thing automatically. No `setName()` is required, no `__ps_name` storage record is written, and cold-wake recovery happens for free because the factory re-runs and `idFromName` is deterministic.

### What ships

- **README.md** — rewrote the `.name` description; added a new "Using PartyServer with Durable Object Facets" section that walks through the recommended pattern with a code example, calls out the implicit-id footgun, and warns that plain-string `id` values are not a substitute for `idFromName(facetName)` (workerd treats string ids as `idFromString`-like, so the resulting facet has no `ctx.id.name`).
- **`setName()` docstring** — clarified that facets are NOT a `setName()` use case; pointed readers at the explicit-`id` pattern. The `setName()` `ctx.id.name` mismatch throw is preserved as a typo guard for the `idFromName` happy path.
- **`#hydrateNameFromLegacyStorage` docstring** — corrected to no longer claim that Cloudflare Agents facets use this fallback.
- **End-to-end test coverage** — `FacetParent` / `FacetChild` fixtures plus a `describe("facets …")` block in `index.test.ts` that covers:
  - implicit-id flow (pins the runtime contract: `this.name` returns the parent's name; documentation-via-test so future readers aren't surprised)
  - explicit-id flow via env binding (`env.SomeNs.idFromName`)
  - explicit-id flow via `ctx.exports[BoundClass].idFromName` (no env knowledge required — the recommended pattern for framework code)
  - plain-string `id` (negative case: produces a facet with `ctx.id.name === undefined`, `this.name` throws)
  - cold-wake recovery on the explicit-id path (no storage record involved; deterministic factory re-run carries the name)
- **Sibling packages** (`hono-party`, `partysub`, `partysync`, `partywhen`, `y-partyserver`) — devDependency bumped from `partyserver: ^0.5.1` → `^0.5.2` for consistency.
- **CHANGELOG.md** — minor formatting cleanup.
- **Changeset** — `.changeset/facet-name-resolution.md`, patch bump.

### Why docs/tests instead of a runtime fix

The previous draft of this work added a runtime override mechanism in `Server` (getter precedence flip, hydrate gate change, removed setName guard). That worked but introduced behavior changes for non-facet users (silent override on `setName()` mismatch, ~1ms storage GET per cold wake on every DO). With the discovery that `FacetStartupOptions.id` is the documented Cloudflare API for "give this facet its own identity," the override mechanism is unnecessary. We're going *with* the runtime contract instead of around it, which:

- preserves byte-identical behavior for all existing users;
- is forward-compatible with future workerd facet capabilities tied to `ctx.id`;
- doesn't require sibling frameworks to adopt new partyserver patterns.

The Cloudflare Agents repo is migrating its `_cf_initAsFacet` to pass `id` to `ctx.facets.get()` in a separate PR; this PR is the partyserver-side documentation that makes that pattern discoverable for everyone else.

## Test plan

- [x] `npm run check:test` passes (60/60, including 3 new facet tests against the real `ctx.facets.get()` API)
- [x] `npm run check:type` passes (all 41 projects)
- [x] `npm run check:lint` passes
- [x] End-to-end validation against the actual consumer ([cloudflare/agents](https://github.com/cloudflare/agents)) using a local-tarball install: full workers test project (1006 tests) passes
- [ ] Reviewer to spot-check the README facet section for clarity

Made with [Cursor](https://cursor.com)