### PR TITLE
Honor options.fetch on /generate-ice-servers request

### DIFF
--- a/.changeset/sleek-otters-pass-fetch.md
+++ b/.changeset/sleek-otters-pass-fetch.md
@@ -1,0 +1,5 @@
+---
+"partytracks": patch
+---
+
+Pass `options.fetch` to `fromFetch` when fetching `/generate-ice-servers`. The matching `sessions/new` request already uses it, so a consumer that wires up a custom `fetch` via `PartyTracksConfig.fetch` (for auth headers, tracing, retries, request signing, etc.) now gets it applied uniformly across both calls instead of just one. No behavior change for consumers that don't pass a custom fetch — `fetchImpl` defaults to the global `fetch` in `fromFetch.ts`.

--- a/packages/partytracks/src/client/PartyTracks.ts
+++ b/packages/partytracks/src/client/PartyTracks.ts
@@ -761,6 +761,7 @@ function makePeerConnectionSessionCombo(options: {
     iceServers: options.iceServers
       ? of(options.iceServers)
       : fromFetch(`${options.prefix}/generate-ice-servers`, {
+          fetchImpl: options.fetch,
           selector: (res) =>
             res
               .json()


### PR DESCRIPTION
Tiny one-line fix in `makePeerConnectionSessionCombo`. The `sessions/new` request honors `options.fetch` via `fetchImpl`, but the `/generate-ice-servers` request doesn't — they should match.

If a consumer wires up a custom `fetch` via `PartyTracksConfig.fetch` (to inject auth headers, add tracing, retry on transient failures, sign requests, etc.), it currently silently doesn't apply to the iceServers GET. So whatever that fetch was doing — Authorization headers, request signing, anything — gets dropped on that one request.

```diff
     iceServers: options.iceServers
       ? of(options.iceServers)
       : fromFetch(`${options.prefix}/generate-ice-servers`, {
+          fetchImpl: options.fetch,
           selector: (res) =>
             res
               .json()
               .then(
                 (body) => (body as { iceServers: RTCIceServer[] }).iceServers
               )
         })
```

No behavior change for consumers that don't pass a custom fetch — `fetchImpl` defaults to the global `fetch` in `fromFetch.ts:35`.

Changeset added (patch). Happy to add a unit test if you want one — let me know your preferred shape since the existing tests in `tests/` don't currently exercise the `fetchImpl` plumbing.

---

_Disclosure: drafted with help from an AI coding assistant (Claude), reviewed and tested locally before opening._