### PR TITLE
fix(partysocket): avoid module-scope random default

### DIFF
--- a/.changeset/ninety-turtles-taste.md
+++ b/.changeset/ninety-turtles-taste.md
@@ -1,0 +1,5 @@
+---
+"partysocket": patch
+---
+
+fix(partysocket): avoid module-scope random default

--- a/packages/partysocket/src/tests/module-scope.test.ts
+++ b/packages/partysocket/src/tests/module-scope.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @vitest-environment node
+ */
+
+import { afterEach, expect, test, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("does not generate random values while importing the websocket module", async () => {
+  vi.resetModules();
+  const random = vi.spyOn(Math, "random");
+
+  await import("../ws");
+
+  expect(random).not.toHaveBeenCalled();
+});

--- a/packages/partysocket/src/ws.ts
+++ b/packages/partysocket/src/ws.ts
@@ -124,7 +124,7 @@ export type Options = {
 
 const DEFAULT = {
   maxReconnectionDelay: 10000,
-  minReconnectionDelay: 1000 + Math.random() * 4000,
+  minReconnectionDelay: 3000,
   minUptime: 5000,
   reconnectionDelayGrowFactor: 1.3,
   connectionTimeout: 4000,


### PR DESCRIPTION
## Summary

Avoid calling `Math.random()` while `partysocket/ws` is imported by replacing the module-scope randomized default `minReconnectionDelay` with the deterministic midpoint of the previous range.

This keeps the public `minReconnectionDelay` option unchanged, while making the default safe for Worker/server runtimes that reject random-value generation during module evaluation.

## Why

Cloudflare Workers disallow random value generation in global scope. In SSR/RSC environments running inside Workerd, importing client component trees can evaluate `partysocket/ws` on the server, which currently trips that restriction via the top-level default object.

## Tests

- `npx oxfmt --check packages/partysocket/src/ws.ts packages/partysocket/src/tests/module-scope.test.ts`
- `npm run check:test -w partysocket -- src/tests/module-scope.test.ts`
- `npm run check:test -w partysocket`
- `npm run build -w partysocket`