### PR TITLE
fix: allow user-defined interfaces as Server Props

### DIFF
--- a/.changeset/olive-frogs-invent.md
+++ b/.changeset/olive-frogs-invent.md
@@ -1,0 +1,7 @@
+---
+"partyserver": patch
+---
+
+Allow user-defined interfaces as `Props`.
+
+Interfaces do not get implicit index signatures in TypeScript, so the previous `Record<string, unknown>` bound rejected them with "Index signature for type 'string' is missing". `Props` is now bounded by `object` on `Server`, `getServerByName`, and `routePartykitRequest`, and the `T` constraints on the latter two are `Server<Env, object>` so subclasses declaring interface `Props` satisfy them too. Generic defaults stay `Record<string, unknown>`, so untyped usage still reads props values as `unknown`.

--- a/packages/partyserver/src/index.ts
+++ b/packages/partyserver/src/index.ts
@@ -291,8 +291,8 @@ function decodeProps(header: string): unknown {
  */
 export async function getServerByName<
   Env extends Cloudflare.Env = Cloudflare.Env,
-  T extends Server<Env> = Server<Env>,
-  Props extends Record<string, unknown> = Record<string, unknown>
+  T extends Server<Env, object> = Server<Env>,
+  Props extends object = Record<string, unknown>
 >(
   serverNamespace: DurableObjectNamespace<T>,
   name: string,
@@ -428,8 +428,8 @@ function resolveCorsHeaders(
 
 export async function routePartykitRequest<
   Env extends Cloudflare.Env = Cloudflare.Env,
-  T extends Server<Env> = Server<Env>,
-  Props extends Record<string, unknown> = Record<string, unknown>
+  T extends Server<Env, object> = Server<Env>,
+  Props extends object = Record<string, unknown>
 >(
   req: Request,
   env: Env = defaultEnv as Env,
@@ -586,9 +586,15 @@ Did you forget to add a durable object binding to the class ${namespace[0].toUpp
   }
 }
 
+/**
+ * @template Env Environment type containing bindings
+ * @template Props Initial-props type delivered to `onStart()`. Bounded by
+ * `object` rather than `Record<string, unknown>` so user-defined interfaces
+ * qualify — interfaces have no implicit index signature.
+ */
 export class Server<
   Env extends Cloudflare.Env = Cloudflare.Env,
-  Props extends Record<string, unknown> = Record<string, unknown>
+  Props extends object = Record<string, unknown>
 > extends DurableObject<Env> {
   static options: { hibernate?: boolean } = {
     hibernate: false

--- a/packages/partyserver/src/tests/props.test-d.ts
+++ b/packages/partyserver/src/tests/props.test-d.ts
@@ -1,0 +1,53 @@
+/**
+ * Type tests for Server props typing. Compile-time only — this file is
+ * typechecked but never executed (vitest only picks up `*.test.ts`).
+ *
+ * Interfaces do not get implicit index signatures in TypeScript, so a
+ * `Record<string, unknown>` bound rejects user-defined interfaces with
+ * "Index signature for type 'string' is missing". Props bounds must accept
+ * plain interfaces while still rejecting non-object props.
+ */
+import { Server, getServerByName, routePartykitRequest } from "../index";
+
+// A well-defined interface with NO index signature.
+interface AuthProps {
+  userId: string;
+  permissions: string[];
+}
+
+declare const authProps: AuthProps;
+declare const env: Cloudflare.Env;
+declare const request: Request;
+
+// ============================================
+// POSITIVE TESTS - interface props must be accepted
+// ============================================
+
+// Server must be instantiable with interface Props.
+declare class AuthServer extends Server<Cloudflare.Env, AuthProps> {}
+declare const serverNamespace: DurableObjectNamespace<AuthServer>;
+
+// getServerByName must accept interface-typed props.
+getServerByName(serverNamespace, "instance", { props: authProps });
+
+// onStart receives the interface type.
+declare const authServer: AuthServer;
+authServer.onStart(authProps);
+
+// routePartykitRequest must accept interface-typed props.
+routePartykitRequest(request, env, { props: authProps });
+
+// ============================================
+// NEGATIVE TESTS - non-object props stay rejected
+// ============================================
+
+// @ts-expect-error — a primitive is not a props bag
+declare class BadServer extends Server<Cloudflare.Env, string> {}
+
+getServerByName(serverNamespace, "instance", {
+  // @ts-expect-error — a primitive is not a props bag
+  props: "not-an-object"
+});
+
+// Silence unused-declaration noise; this file only exists to typecheck.
+export type {};


### PR DESCRIPTION
## Summary

The `Props` generic on `Server`, `getServerByName`, and `routePartykitRequest` was bounded by `Record<string, unknown>`. Interfaces do not get implicit index signatures in TypeScript, so a well-typed interface fails that bound with:

```
Type 'MyProps' is not assignable to type 'Record<string, unknown>'.
  Index signature for type 'string' is missing in type 'MyProps'.
```

This surfaced downstream as cloudflare/agents#1886 (`getAgentByName(ns, name, { props: config })` rejecting interface-typed props) — the agents SDK inherits these bounds through `Server` and `getServerByName`, so the root fix belongs here.

## Fix — `object` bounds, no `any`, no casts

- **`Props extends object = Record<string, unknown>`** on `Server`, `getServerByName`, and `routePartykitRequest`. Interfaces satisfy `object` natively; defaults stay `Record<string, unknown>` so untyped usage still reads props values as `unknown`. Props is only ever treated as an opaque JSON bag at runtime (`encodeProps`/`decodeProps` already type it `unknown`), so nothing behavioral changes.
- **`T extends Server<Env, object> = Server<Env>`** on `getServerByName`/`routePartykitRequest`. Two things forced this: the `#_props` private field carries `Props` covariantly, so a subclass declaring interface Props failed the old `Server<Env>` constraint (whose Props silently pinned to the `Record` default); and the DO stub's `setName` parameter resolves from the constraint, so `options.props` wouldn't flow without it. The *default* stays `Server<Env>`, keeping the return type for untyped callers identical.

## Repro / regression tests

New compile-time test `packages/partyserver/src/tests/props.test-d.ts` — typechecked by `check:type` but never executed (vitest only picks up `*.test.ts`). Written first and confirmed red on main with errors matching the report:
- `Server` declared with interface `Props`
- `getServerByName` / `routePartykitRequest` called with interface-typed props
- `onStart` receiving the interface type
- negative pins: primitives are still rejected as `Props`

## Verification

`npm run build && npm run check` fully green (sherif, oxfmt, oxlint, all 42 typecheck projects, all workspace test suites).

Once this ships, cloudflare/agents can bump `partyserver` and loosen its own `Props` bounds without any bridging (supersedes the approach in cloudflare/agents#1906, closed in favor of fixing it here).